### PR TITLE
Configure Claude Code to use LSP ; Document git branching strategy in CLAUDE.md

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -29,6 +29,9 @@ brew "basedpyright"  # Python language server (faster than pyright)
 brew "marksman"  # Markdown language server
 brew "yaml-language-server"  # YAML language server
 brew "texlab"  # LaTeX language server
+brew "typescript-language-server"  # TypeScript/JavaScript language server
+brew "vscode-langservers-extracted"  # JSON, HTML, CSS, ESLint language servers
+brew "bash-language-server"  # Bash/Shell script language server
 
 # Linters & Formatters
 brew "golangci-lint"  # Go meta-linter

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,18 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-his is a **chezmoi-managed dotfiles repository** for managing personal configuration across macOS, FreeBSD, and Linux systems. The repository uses chezmoi's templating system with 1Password integration for secrets management.
+This is a **chezmoi-managed dotfiles repository** for managing personal configuration across macOS, FreeBSD, and Linux systems. The repository uses chezmoi's templating system with 1Password integration for secrets management.
+
+## Git Workflow
+
+**This repository typically works directly on the `master` branch.**
+
+Since this is a personal dotfiles repository managing system configurations, changes are usually committed directly to master. Feature branches should be **infrequent** and only used for:
+- Major refactoring or architectural changes
+- Experimental configurations that need testing before deployment
+- Changes that require review or collaboration
+
+For routine configuration updates (adding packages, updating settings, fixing bugs), commit directly to master.
 
 ## Key Architecture Patterns
 

--- a/dot_claude/README.md
+++ b/dot_claude/README.md
@@ -8,7 +8,7 @@ This directory contains unified configuration for both **Claude Code** (CLI) and
 
 | File | Purpose | Used By |
 |------|---------|---------|
-| `config.json.tmpl` | MCP server configuration | Claude Code (CLI) |
+| `config.json.tmpl` | MCP servers + LSP configuration | Claude Code (CLI) |
 | `settings.json.tmpl` | Basic CLI settings | Claude Code (CLI) |
 | `plugins/config.json.tmpl` | Plugin-specific settings | Claude Code plugins |
 | `../Library/.../claude_desktop_config.json.tmpl` | MCP server configuration | Claude Desktop (GUI) |
@@ -71,6 +71,58 @@ The configuration uses a **unified template approach** where MCP server definiti
 
 - **incidentio**: Incident.io integration with 1Password API key
 - **GitLab**: GitLab MCP HTTP integration
+
+## LSP (Language Server Protocol) Configuration
+
+Claude Code v2.0.74+ includes LSP support. The configuration uses the same language servers installed for Vim, providing consistent IDE features across both editors.
+
+### Configured Language Servers
+
+| Language Server | Languages | Features |
+|----------------|-----------|----------|
+| **gopls** | Go | Code completion, go-to-definition, diagnostics, refactoring |
+| **basedpyright** | Python | Type checking, completion, diagnostics |
+| **marksman** | Markdown | Completion, navigation, diagnostics |
+| **yaml-language-server** | YAML | Schema validation, completion (GitHub Actions, GitLab CI, Docker Compose) |
+| **texlab** | LaTeX, BibTeX | Completion, build support, navigation |
+| **typescript-language-server** | TypeScript, JavaScript | Full TS/JS support, JSX/TSX |
+| **vscode-json-language-server** | JSON, JSONC | Schema validation, completion |
+| **bash-language-server** | Bash, Shell | Completion, diagnostics, shellcheck integration |
+
+### LSP Features
+
+- **Code Completion**: Intelligent suggestions based on context
+- **Go to Definition**: Navigate to symbol definitions
+- **Find References**: Find all usages of a symbol
+- **Diagnostics**: Real-time error and warning detection
+- **Hover Documentation**: View documentation on hover
+- **Code Actions**: Quick fixes and refactoring suggestions
+- **Formatting**: Auto-format on save
+
+### Configuration Details
+
+The LSP configuration in `config.json.tmpl` includes:
+
+- **Root Pattern Detection**: Automatically detects project roots (e.g., `go.mod`, `package.json`, `.git`)
+- **File Type Association**: Maps file extensions to appropriate language servers
+- **Server-Specific Settings**: Optimized settings for each language server
+- **YAML Schema Integration**: Automatic schema validation for GitHub Actions, GitLab CI, and Docker Compose files
+
+### Installation
+
+All language servers are installed via Homebrew (see Brewfile):
+
+```bash
+brew install gopls basedpyright marksman yaml-language-server texlab \
+             typescript-language-server vscode-langservers-extracted \
+             bash-language-server
+```
+
+Or install all dependencies at once:
+
+```bash
+brew bundle install
+```
 
 ## Template Logic
 

--- a/dot_claude/config.json.tmpl
+++ b/dot_claude/config.json.tmpl
@@ -5,5 +5,91 @@
 {{- if eq .chezmoi.username "cobrien" }},
 {{ includeTemplate "dot_claude/mcp-servers-work.json.tmpl" . | indent 4 }}
 {{- end }}
+  },
+  "lsp": {
+    "enabled": true,
+    "servers": {
+      "gopls": {
+        "command": "gopls",
+        "args": ["serve"],
+        "rootPatterns": ["go.mod", "go.work", ".git"],
+        "filetypes": ["go"],
+        "settings": {
+          "gopls": {
+            "analyses": {
+              "unusedparams": true,
+              "shadow": true
+            },
+            "staticcheck": true,
+            "gofumpt": true
+          }
+        }
+      },
+      "basedpyright": {
+        "command": "basedpyright-langserver",
+        "args": ["--stdio"],
+        "rootPatterns": ["pyproject.toml", "setup.py", "setup.cfg", "requirements.txt", ".git"],
+        "filetypes": ["python"],
+        "settings": {
+          "basedpyright": {
+            "analysis": {
+              "typeCheckingMode": "basic",
+              "autoSearchPaths": true,
+              "useLibraryCodeForTypes": true
+            }
+          }
+        }
+      },
+      "marksman": {
+        "command": "marksman",
+        "args": ["server"],
+        "rootPatterns": [".git", ".marksman.toml"],
+        "filetypes": ["markdown"]
+      },
+      "yaml-language-server": {
+        "command": "yaml-language-server",
+        "args": ["--stdio"],
+        "rootPatterns": [".git"],
+        "filetypes": ["yaml", "yml"],
+        "settings": {
+          "yaml": {
+            "format": {
+              "enable": true
+            },
+            "validate": true,
+            "hover": true,
+            "completion": true,
+            "schemas": {
+              "https://json.schemastore.org/github-workflow.json": ".github/workflows/*.{yml,yaml}",
+              "https://json.schemastore.org/gitlab-ci.json": ".gitlab-ci.{yml,yaml}",
+              "https://raw.githubusercontent.com/docker/compose/master/compose/config/compose_spec.json": "docker-compose*.{yml,yaml}"
+            }
+          }
+        }
+      },
+      "texlab": {
+        "command": "texlab",
+        "rootPatterns": [".git"],
+        "filetypes": ["tex", "latex", "bib"]
+      },
+      "typescript-language-server": {
+        "command": "typescript-language-server",
+        "args": ["--stdio"],
+        "rootPatterns": ["package.json", "tsconfig.json", "jsconfig.json", ".git"],
+        "filetypes": ["javascript", "javascriptreact", "typescript", "typescriptreact"]
+      },
+      "vscode-json-language-server": {
+        "command": "vscode-json-language-server",
+        "args": ["--stdio"],
+        "rootPatterns": [".git"],
+        "filetypes": ["json", "jsonc"]
+      },
+      "bash-language-server": {
+        "command": "bash-language-server",
+        "args": ["start"],
+        "rootPatterns": [".git"],
+        "filetypes": ["sh", "bash"]
+      }
+    }
   }
 }


### PR DESCRIPTION
* Document the repo branching strategy in CLAUDE.md, so it doesn't need to be explicitly declared every time
* Configure Claude Code to use LSP support, using the same local LSP binaries recently added to vimrc as well


Co-Authored-By: Claude Code + Claude Sonnet 4.5, with the prompts:

```
Let's add a note to CLAUDE.md that this dotfiles repo typically just works on the master branch, since the repo is managing configs. Any feature branches in this repo will be infrequent
```

```
Since Claude Code v2.0.74 now supports LSP, let's configure Claude Code to use the same local LSP we recently configured in vim
```