### PR TITLE
Configure Claude Subagents

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -14,6 +14,17 @@
 # Workflow
 * When working on Github repositories under github.com/conallob , always install Claude App and Claude Github Actions
 * When working on Github Pull Requests, always address all PR feedback provided by Claude Code Review
+* When creating Pull Requests, include the primary prompts as multiline markdown code blocks in the PR description
+  - This provides context for reviewers about the original intent and scope
+  - Format prompts using markdown code fences (triple backticks)
+  - Example format in PR description:
+    ```
+    ## Original Prompt
+
+    ```
+    Create a new branch to update @dot_claude/CLAUDE.md to use subagents...
+    ```
+    ```
 
 # Subagents
 

--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -14,3 +14,27 @@
 # Workflow
 * When working on Github repositories under github.com/conallob , always install Claude App and Claude Github Actions
 * When working on Github Pull Requests, always address all PR feedback provided by Claude Code Review
+
+# Subagents
+
+Use specialized subagents to handle complex, repetitive tasks more efficiently:
+
+## GitHub Actions Subagent
+
+When working with Pull Requests, use a subagent to monitor GitHub Actions:
+* Instead of repeatedly checking and copying GitHub Actions output manually
+* Launch a general-purpose subagent to monitor the PR's CI/CD pipeline
+* The subagent should use `gh` commands to check workflow runs and report status
+* Example tasks:
+  - Monitor workflow runs for a specific PR
+  - Report failures with relevant error logs
+  - Wait for all checks to pass before proceeding
+
+## Lint and Test Subagent
+
+Before committing changes to a branch, use a subagent to run linting and tests:
+* Launch a general-purpose subagent to run all relevant linters and tests for the codebase
+* For Go projects: run `golangci-lint`, `go fmt`, and `go test`
+* For Python projects: run `black`, `ruff`, and `pytest`
+* The subagent should report all issues found and only mark complete when all checks pass
+* This ensures code quality before creating commits or push requests

--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -34,7 +34,7 @@ When working with Pull Requests, use a subagent to monitor GitHub Actions:
 
 Before committing changes to a branch, use a subagent to run linting and tests:
 * Launch a general-purpose subagent to run all relevant linters and tests for the codebase
-* For Go projects: run `golangci-lint`, `go fmt`, and `go test`
-* For Python projects: run `black`, `ruff`, and `pytest`
+* The subagent should first inspect `.github/workflows/` to detect what linters and test commands are configured
+* Run the same commands that GitHub Actions will run to ensure local checks match CI/CD
 * The subagent should report all issues found and only mark complete when all checks pass
-* This ensures code quality before creating commits or push requests
+* This ensures code quality before creating commits or push requests and prevents CI failures

--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -32,7 +32,7 @@ Use specialized subagents to handle complex, repetitive tasks more efficiently:
 
 ## GitHub Actions Subagent
 
-When working with Pull Requests, use a subagent to monitor GitHub Actions:
+When working with GitHub Pull Requests, use a subagent to monitor GitHub Actions:
 * Instead of repeatedly checking and copying GitHub Actions output manually
 * Launch a general-purpose subagent to monitor the PR's CI/CD pipeline
 * The subagent should use `gh` commands to check workflow runs and report status


### PR DESCRIPTION
Configure Claude sub-agents, for:

* Managing Github, fetching data from PRs, CI logs, etc
* Test and Lint code, after detecting the test and lint Github Actions workflows
* Document the primary prompts as multiline markdown code blocks in PR descriptions


```
Update @dot_claude/CLAUDE.md to use subagents.

One subagent to manage interacting with Github to check github actions output for a PR, instead of endlessly copying output into the chat interface over and over and over

Another subagent to always lint and test the code in a branch locally
```

```
For the subagent to test and lint code, it should detect what linters and test commands are configured in github actions
```

```
Also update @dot_claude/CLAUDE.md to document the primary prompts as multiline mardown code in the PR description, similar to how I have done in PR descriptions and previous commit messages
```