### PR TITLE
Extend subagent support from GitHub to GitHub and GitLab

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -13,11 +13,11 @@
 
 # Workflow
 * When working on Github repositories under github.com/conallob , always install Claude App and Claude Github Actions
-* When working on Github Pull Requests, always address all PR feedback provided by Claude Code Review
-* When creating Pull Requests, include the primary prompts as multiline markdown code blocks in the PR description
+* When working on GitHub Pull Requests or GitLab Merge Requests, always address all PR/MR feedback provided by Claude Code Review
+* When creating Pull Requests or Merge Requests, include the primary prompts as multiline markdown code blocks in the PR/MR description
   - This provides context for reviewers about the original intent and scope
   - Format prompts using markdown code fences (triple backticks)
-  - Example format in PR description:
+  - Example format in PR/MR description:
     ```
     ## Original Prompt
 
@@ -30,14 +30,15 @@
 
 Use specialized subagents to handle complex, repetitive tasks more efficiently:
 
-## GitHub Actions Subagent
+## CI/CD Monitoring Subagent
 
-When working with GitHub Pull Requests, use a subagent to monitor GitHub Actions:
-* Instead of repeatedly checking and copying GitHub Actions output manually
-* Launch a general-purpose subagent to monitor the PR's CI/CD pipeline
-* The subagent should use `gh` commands to check workflow runs and report status
+When working with GitHub Pull Requests or GitLab Merge Requests, use a subagent to monitor CI/CD pipelines:
+* Instead of repeatedly checking and copying CI/CD output manually
+* Launch a general-purpose subagent to monitor the PR/MR's CI/CD pipeline
+* For GitHub: The subagent should use `gh` commands to check workflow runs and report status
+* For GitLab: The subagent should use `glab` commands to check pipeline runs and report status
 * Example tasks:
-  - Monitor workflow runs for a specific PR
+  - Monitor workflow/pipeline runs for a specific PR/MR
   - Report failures with relevant error logs
   - Wait for all checks to pass before proceeding
 
@@ -45,7 +46,9 @@ When working with GitHub Pull Requests, use a subagent to monitor GitHub Actions
 
 Before committing changes to a branch, use a subagent to run linting and tests:
 * Launch a general-purpose subagent to run all relevant linters and tests for the codebase
-* The subagent should first inspect `.github/workflows/` to detect what linters and test commands are configured
-* Run the same commands that GitHub Actions will run to ensure local checks match CI/CD
+* The subagent should first inspect CI configuration to detect what linters and test commands are configured:
+  - For GitHub: Check `.github/workflows/` for GitHub Actions workflows
+  - For GitLab: Check `.gitlab-ci.yml` and any yaml files under `.gitlab/` for GitLab CI configuration
+* Run the same commands that the CI/CD platform will run to ensure local checks match CI/CD
 * The subagent should report all issues found and only mark complete when all checks pass
 * This ensures code quality before creating commits or push requests and prevents CI failures


### PR DESCRIPTION
Expand CI/CD integration to support both GitHub and GitLab platforms:

Workflow updates:
- Support GitHub Pull Requests AND GitLab Merge Requests
- Include primary prompts in PR/MR descriptions for both platforms

CI/CD Monitoring Subagent (renamed from GitHub Actions Subagent):
- Monitor both GitHub Actions (using `gh` CLI) and GitLab CI (using `glab` CLI)
- Renamed to be platform-agnostic
- Track workflows/pipelines for PRs/MRs on either platform

Lint and Test Subagent:
- Detect GitHub Actions config in `.github/workflows/`
- Detect GitLab CI config in `.gitlab-ci.yml` and yaml files under `.gitlab/`
- Auto-detect and run the same commands configured in the CI/CD platform

This makes the subagent instructions work across both major git platforms.