### PR TITLE
Add OSC 52 clipboard support for SSH and tmux

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -10,3 +10,8 @@ desktop-notifications = true
 
 # Terminal bell (visual and audio)
 shell-integration-features = cursor,sudo,title
+
+# Clipboard (OSC 52)
+clipboard-read = allow
+clipboard-write = allow
+copy-on-select = clipboard

--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -1,0 +1,11 @@
+# ============================================================================
+# tmux configuration
+# ============================================================================
+
+# ============================================================================
+# Clipboard (OSC 52)
+# ============================================================================
+# Allow applications inside tmux to set the terminal clipboard via OSC 52.
+# 'on' makes tmux intercept OSC 52 and populate its own clipboard buffer,
+# then forward the sequence to the outer terminal (e.g. ghostty).
+set -g set-clipboard on

--- a/dot_vim/vimrc
+++ b/dot_vim/vimrc
@@ -113,6 +113,9 @@ Plug 'jiangmiao/auto-pairs'                         " Auto-close brackets
 Plug 'yggdroot/indentline'                          " Show indent guides
 Plug 'editorconfig/editorconfig-vim'                " EditorConfig support
 
+" --- Clipboard ---
+Plug 'ojroques/vim-oscyank', {'branch': 'main'}     " OSC 52 clipboard (works over SSH, without X11)
+
 call plug#end()
 
 " ============================================================================
@@ -621,4 +624,14 @@ if exists('*glaive#Install')
   call glaive#Install()
   " Optional: configure vim-codefmt with glaive
   " Glaive codefmt plugin[mappings]
+endif
+
+" ============================================================================
+" OSC 52 Clipboard (vim-oscyank)
+" ============================================================================
+" Automatically sync yanks to the terminal clipboard via OSC 52.
+" Works over SSH and without X11 (complements 'vim -X' alias).
+" Triggers whenever text is yanked to the + register (clipboard=unnamedplus).
+if exists('g:loaded_oscyank')
+  autocmd TextYankPost * if v:event.operator is 'y' && v:event.regname is '+' | execute 'OSCYankRegister +' | endif
 endif


### PR DESCRIPTION
## Summary
This PR adds OSC 52 clipboard support across Vim, tmux, and Ghostty, enabling seamless clipboard synchronization over SSH and within tmux sessions without requiring X11.

## Key Changes
- **Vim**: Added `vim-oscyank` plugin to sync yanks to the terminal clipboard via OSC 52 protocol. Configured an autocmd to automatically trigger OSC 52 when text is yanked to the clipboard register.
- **tmux**: Created new configuration file with `set-clipboard on` to allow applications inside tmux to set the terminal clipboard via OSC 52 and forward the sequence to the outer terminal.
- **Ghostty**: Enabled OSC 52 clipboard support with `clipboard-read` and `clipboard-write` permissions, and configured `copy-on-select` to use the clipboard.

## Implementation Details
- The Vim autocmd specifically targets the `+` register (clipboard) and only triggers on yank operations (`v:event.operator is 'y'`), ensuring efficient clipboard synchronization.
- The tmux configuration uses `set-clipboard on` to intercept OSC 52 sequences and populate tmux's clipboard buffer while forwarding to the outer terminal.
- This setup complements the `vim -X` alias (which disables X11 forwarding) and provides a modern alternative to traditional clipboard mechanisms that don't work well over SSH.

https://claude.ai/code/session_01PA2LrDrLSSnVbJ7zBWDD2V