### PR TITLE
Add OSC 52 pbcopy shim for non-macOS shells

### DIFF
--- a/shell.d/alias
+++ b/shell.d/alias
@@ -20,3 +20,10 @@ if [ -e "${CONFIGS}/alias.$(hostname -s)" ];
 then
   source "${CONFIGS}/alias.$(hostname -s)"
 fi
+
+# On non-macOS systems, load OSC 52 clipboard helpers (pbcopy shim, copy function).
+# macOS has pbcopy/pbpaste natively; other platforms need the OSC 52 path.
+if [ "$(uname -s)" != "Darwin" ] && [ -e "${CONFIGS}/alias.remote-clipboard" ];
+then
+  source "${CONFIGS}/alias.remote-clipboard"
+fi


### PR DESCRIPTION
shell.d/alias.remote-clipboard: new file with a copy() function that writes stdin to the terminal clipboard via OSC 52, and a pbcopy alias pointing to it so macOS-targeting scripts work unchanged on Linux/FreeBSD.

shell.d/alias: source alias.remote-clipboard when uname is not Darwin.

https://claude.ai/code/session_01PA2LrDrLSSnVbJ7zBWDD2V