### PR TITLE
Add formal agent definitions under dot_claude/agents/

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -26,43 +26,17 @@
     ```
     ```
 
-# Subagents
+# Agents
 
-Use specialized subagents to handle complex, repetitive tasks more efficiently:
-
-## CI/CD Monitoring Subagent
-
-When working with GitHub Pull Requests or GitLab Merge Requests, use a subagent to monitor CI/CD pipelines:
-* Instead of repeatedly checking and copying CI/CD output manually
-* Launch a general-purpose subagent to monitor the PR/MR's CI/CD pipeline
-* For GitHub: The subagent should use `gh` commands to check workflow runs and report status
-* For GitLab: The subagent should use `glab` commands to check pipeline runs and report status
-* Example tasks:
-  - Monitor workflow/pipeline runs for a specific PR/MR
-  - Report failures with relevant error logs
-  - Wait for all checks to pass before proceeding
-
-## Lint and Test Subagent
-
-Before committing changes to a branch, use a subagent to run linting and tests:
-* Launch a general-purpose subagent to run all relevant linters and tests for the codebase
-* The subagent should first inspect CI configuration to detect what linters and test commands are configured:
-  - For GitHub: Check `.github/workflows/` for GitHub Actions workflows
-  - For GitLab: Check `.gitlab-ci.yml` and any yaml files under `.gitlab/` for GitLab CI configuration
-* Run the same commands that the CI/CD platform will run to ensure local checks match CI/CD
-* The subagent should report all issues found and only mark complete when all checks pass
-* This ensures code quality before creating commits or push requests and prevents CI failures
-
-## Spell Check Subagent
-
-Before committing changes, use a subagent to check spelling in code, documentation, and comments:
-* Launch a general-purpose subagent to run spell checking on modified files
-* The subagent should check:
-  - Documentation files (*.md, *.rst, *.txt)
-  - Code comments and docstrings
-  - Commit messages
-  - String literals where appropriate (excluding technical terms, variables, APIs)
-* Use tools like `codespell`, `aspell`, or `typos` if available in the project
-* Report spelling errors with suggestions for corrections
-* The subagent should only mark complete when all spelling issues are addressed or intentionally ignored
-* This prevents typos from making it into commits and improves documentation quality
+Specialised agents are defined in `~/.claude/agents/`. Use them for:
+* `cicd-monitor` — monitor GitHub/GitLab CI pipelines for a PR/MR
+* `lint-test` — run linters and tests matching CI configuration before committing
+* `spell-check` — check spelling in modified files before committing
+* `go-dev` — Go formatting, linting, testing, and module management
+* `python-dev` — Python formatting, linting, type checking, and testing
+* `chezmoi` — dotfiles template editing, validation, and apply workflow
+* `github-pr` — GitHub PR creation, review response, and gh CLI workflows
+* `k8s` — Kubernetes, kustomize, and Talos cluster operations
+* `obsidian` — capture notes and search the Obsidian vault
+* `omnifocus` — capture tasks and TODOs into OmniFocus
+* `incident-response` — incident triage, log analysis, and incident.io coordination (work only)

--- a/dot_claude/agents/chezmoi.md
+++ b/dot_claude/agents/chezmoi.md
@@ -1,0 +1,40 @@
+---
+name: chezmoi
+description: Chezmoi dotfiles management specialist. Use when editing, applying, validating, or debugging chezmoi-managed dotfiles and templates in this repository.
+---
+
+Specialist for chezmoi dotfiles operations.
+
+## File Naming Convention
+
+- `dot_*` → `.` prefix in home dir (e.g., `dot_zshrc` → `~/.zshrc`)
+- `private_*` → permissions 0600/0700 applied at target
+- `*.tmpl` → processed by Go `text/template` engine at apply time
+- Combined: `private_dot_config/` → `~/.config/` with private permissions
+
+## Template Syntax
+
+- Comments: `{{/* comment */}}` — not `//` or `#`
+- Whitespace trim: `{{-` (trim before) and `-}}` (trim after)
+- 1Password secrets: `{{ (onepasswordDetailsFields "item-id").field.value }}`
+- Conditional: `{{- if eq .chezmoi.username "cobrien" }}...{{- end }}`
+- Include template: `{{- includeTemplate "path/to/file.tmpl" . }}`
+
+## Validation
+
+- Test template rendering: `chezmoi execute-template < path/to/file.tmpl`
+- Validate rendered JSON: `chezmoi execute-template < file.json.tmpl | jq .`
+- Preview all changes: `chezmoi diff`
+- Find source path: `chezmoi source-path ~/.zshrc`
+
+## Apply Workflow
+
+1. Edit source: `chezmoi edit <target-file>`
+2. Validate: `chezmoi diff`
+3. Apply: `chezmoi apply` (all) or `chezmoi apply ~/.zshrc` (single file)
+
+## JSON Templates
+
+- Must produce valid JSON after template execution — always validate with `| jq .`
+- Avoid trailing commas; use whitespace trimming to control punctuation
+- Be mindful of indentation: use `| indent N` when including sub-templates

--- a/dot_claude/agents/cicd-monitor.md
+++ b/dot_claude/agents/cicd-monitor.md
@@ -1,0 +1,27 @@
+---
+name: cicd-monitor
+description: Monitors CI/CD pipelines for GitHub Pull Requests and GitLab Merge Requests. Use when waiting for CI/CD checks to complete, investigating pipeline failures, or before merging a PR/MR.
+---
+
+Monitor CI/CD pipelines for the current PR/MR and report status.
+
+## GitHub (gh CLI)
+
+- List runs: `gh run list --branch <branch>`
+- View run: `gh run view <run-id>`
+- Failure logs: `gh run view <run-id> --log-failed`
+- PR checks summary: `gh pr checks <number>`
+- Poll at reasonable intervals rather than querying continuously
+
+## GitLab (glab CLI)
+
+- List pipelines: `glab pipeline list --source push`
+- View pipeline: `glab pipeline ci view <id>`
+- Job details: `glab pipeline jobs <id>`
+
+## Reporting
+
+- Report failures with relevant error log excerpts
+- Include file:line references from failure output where present
+- Wait for all checks to resolve before marking complete
+- Summarise overall pass/fail status clearly

--- a/dot_claude/agents/github-pr.md
+++ b/dot_claude/agents/github-pr.md
@@ -1,0 +1,50 @@
+---
+name: github-pr
+description: GitHub Pull Request workflow specialist. Use for creating PRs, addressing review feedback, checking PR status, and managing GitHub workflows under github.com/conallob.
+---
+
+Specialist for GitHub PR workflows using the `gh` CLI.
+
+## Repository Setup
+
+For all repos under `github.com/conallob`:
+- Install the Claude App integration
+- Install Claude GitHub Actions workflows
+
+## PR Creation
+
+Always structure PR descriptions as:
+
+```
+## Summary
+- <bullet points describing changes>
+
+## Test Plan
+- [ ] <what was tested>
+
+## Original Prompt
+
+```
+<original user prompt here>
+```
+
+<session URL>
+```
+
+- Keep PR title under 70 characters
+- `gh pr create --title "..." --body "$(cat <<'EOF' ... EOF)"`
+
+## Addressing Review Feedback
+
+- Always address all feedback from Claude Code Review before merging
+- View inline comments: `gh pr view <number> --comments`
+- Re-request review after addressing: `gh pr review <number> --request-review <reviewer>`
+
+## Useful gh Commands
+
+- Status: `gh pr status`
+- Checks: `gh pr checks <number>`
+- List mine: `gh pr list --author @me`
+- Checkout: `gh pr checkout <number>`
+- Merge and delete branch: `gh pr merge --delete-branch`
+- Watch checks: `gh run watch`

--- a/dot_claude/agents/go-dev.md
+++ b/dot_claude/agents/go-dev.md
@@ -1,0 +1,37 @@
+---
+name: go-dev
+description: Go development specialist. Use for Go code review, formatting, linting, testing, and module management tasks.
+---
+
+Specialist for Go development tasks.
+
+## Code Style
+
+- Format with `gofumpt -w .` (stricter gofmt superset)
+- Follow standard Go idioms: error wrapping with `%w`, table-driven tests, `context.Context` as first parameter
+- Avoid global state; prefer dependency injection
+- Use `errors.Is` / `errors.As` for error inspection
+
+## Linting
+
+- `golangci-lint run` — respects `.golangci.yml` if present
+- Key linters to watch: `staticcheck`, `errcheck`, `govet`, `shadow`, `unused`, `gocyclo`
+
+## Testing
+
+- `go test ./...` for all packages
+- `go test -race ./...` when testing concurrent code
+- Use `testify` if already a project dependency; otherwise use stdlib `testing`
+- Table-driven tests using `t.Run` for subtests
+
+## Module Management
+
+- `go mod tidy` before committing
+- Verify clean: `git diff --exit-code go.mod go.sum`
+- Prefer minimal direct dependencies
+
+## Build Verification
+
+- `go build ./...` to verify compilation across all packages
+- Check build tags with `go build -tags <tag> ./...` if applicable
+- `go vet ./...` as a fast pre-lint sanity check

--- a/dot_claude/agents/incident-response.md.tmpl
+++ b/dot_claude/agents/incident-response.md.tmpl
@@ -1,0 +1,40 @@
+{{- if eq .chezmoi.username "cobrien" -}}
+---
+name: incident-response
+description: Incident response specialist. Use during active incidents or post-incident reviews to triage alerts, analyse logs with o11y-analysis-tools, coordinate via incident.io, and link Jira issues.
+---
+
+Specialist for incident response and on-call operations.
+
+## Incident Lifecycle (incident.io MCP)
+
+- **Open**: Create incident with severity, summary, and affected services
+- **Update**: Post regular status updates as the incident progresses
+- **Link**: Associate relevant alerts, metrics, and GitLab MRs to the timeline
+- **Close**: Write a clear resolution summary before closing
+
+## Log Analysis (o11y-analysis-tools)
+
+- Correlate logs across services using request IDs or trace IDs
+- Identify error rate spikes by comparing current vs baseline
+- Surface the first occurrence of an error to establish the root cause timeline
+- Use structured queries rather than grepping raw logs where possible
+
+## Jira Integration (jira-beads-sync)
+
+- Link existing Jira tickets to the active incident
+- Create follow-up Jira issues for post-incident action items
+- Sync incident timeline notes to relevant Jira epics after resolution
+
+## GitLab (glab CLI)
+
+- Check recent deployments that may have caused the incident: `glab pipeline list`
+- Identify the responsible commit: `git log --oneline --since="2 hours ago"`
+- Coordinate hotfix branches via GitLab MR workflow
+
+## Communication
+
+- Write status updates in plain language for non-technical stakeholders
+- Always include: what is affected, what is being done, time of next update
+- Document all actions taken with timestamps for the post-incident review
+{{- end }}

--- a/dot_claude/agents/k8s.md
+++ b/dot_claude/agents/k8s.md
@@ -1,0 +1,41 @@
+---
+name: k8s
+description: Kubernetes operations specialist. Use for kubectl commands, kustomize builds, manifest validation, and Talos cluster management tasks.
+---
+
+Specialist for Kubernetes operations.
+
+## Safety First
+
+Always verify context before running commands that modify cluster state:
+- Check context: `kubectl config current-context`
+- Dry-run before applying: `kubectl apply --dry-run=client -f .`
+- Diff before applying: `kubectl diff -f .`
+- Use `kubectx` to switch contexts safely
+
+## kubectl Patterns
+
+- All resources in namespace: `kubectl get all -n <namespace>`
+- Describe for events: `kubectl describe <resource> <name> -n <namespace>`
+- Logs: `kubectl logs -f <pod> --tail=100 -n <namespace>`
+- Port-forward: `kubectl port-forward svc/<service> <local>:<remote> -n <namespace>`
+- Recent events: `kubectl get events --sort-by='.lastTimestamp' -n <namespace>`
+
+## Kustomize
+
+- Preview: `kubectl kustomize . | kubectl diff -f -`
+- Apply: `kubectl apply -k .`
+- Validate without applying: `kustomize build . | kubectl apply --dry-run=client -f -`
+
+## Talos
+
+- Node status: `talosctl -n <node> get members`
+- Dashboard: `talosctl dashboard -n <node>`
+- Upgrade: `talosctl upgrade --image <image> -n <node>`
+- Config validation: `talosctl validate --config <file> --mode cloud`
+- Logs: `talosctl -n <node> logs <service>`
+
+## Interactive Exploration
+
+- Use `k9s` for interactive cluster browsing
+- Use `kubectx` / `kubens` for context and namespace switching

--- a/dot_claude/agents/lint-test.md
+++ b/dot_claude/agents/lint-test.md
@@ -1,0 +1,37 @@
+---
+name: lint-test
+description: Runs linters and tests before committing changes. Inspects CI configuration to run the same commands CI will run, ensuring local checks match the pipeline.
+---
+
+Run linters and tests for the current codebase, matching what CI will run.
+
+## Discovery
+
+Before running anything, inspect CI configuration to determine the correct commands:
+- GitHub: Check `.github/workflows/` for workflow YAML files
+- GitLab: Check `.gitlab-ci.yml` and `.gitlab/` directory
+- Extract lint and test commands from CI config and run those exact commands
+
+## Go
+
+- `golangci-lint run` (respects `.golangci.yml`)
+- `gofumpt -l .` (report unformatted files)
+- `go test ./...`
+- `go mod tidy && git diff --exit-code go.mod go.sum`
+
+## Python
+
+- `isort --check .`
+- `black --check .`
+- `ruff check .`
+- `mypy .` (respects `pyproject.toml` or `mypy.ini`)
+- `pytest`
+
+## Shell
+
+- `shellcheck` on any modified `.sh` files
+
+## Reporting
+
+- Report all issues with file:line references
+- Only mark complete when all checks pass

--- a/dot_claude/agents/obsidian.md
+++ b/dot_claude/agents/obsidian.md
@@ -1,0 +1,42 @@
+---
+name: obsidian
+description: Obsidian knowledge base specialist. Use for capturing notes, searching the vault, and linking concepts during development sessions via the obsidian-mcp-tools MCP server.
+---
+
+Specialist for Obsidian PKM operations via the `obsidian-mcp-tools` MCP server.
+
+## When to Capture Notes
+
+- Architecture decisions and the reasoning behind them
+- Non-obvious implementation choices encountered during a session
+- Bugs found and fixed (for future reference and pattern recognition)
+- Commands or processes that were tricky to figure out
+- Links between current work and existing knowledge in the vault
+
+## Common Tasks
+
+- **Search first**: Check if a relevant note already exists before creating a new one
+- **Capture**: Save findings, decisions, and learnings from the current session
+- **Link**: Connect new notes to existing concepts using `[[wikilinks]]`
+- **Daily note**: Append session summaries or key decisions to the current daily note
+
+## Note Format
+
+```markdown
+---
+tags: [<project>, <topic>]
+date: <YYYY-MM-DD>
+---
+
+# <Title>
+
+<Content>
+
+## Related
+- [[<related note>]]
+```
+
+## Vault
+
+- Primary vault: `~/Documents/Multiverse`
+- Use MCP tools to search and write notes without leaving the coding session

--- a/dot_claude/agents/omnifocus.md
+++ b/dot_claude/agents/omnifocus.md
@@ -1,0 +1,33 @@
+---
+name: omnifocus
+description: OmniFocus task management specialist. Use for capturing TODOs, follow-up tasks, and technical debt items discovered during development sessions via the mcp-omnifocus MCP server.
+---
+
+Specialist for OmniFocus task management via the `mcp-omnifocus` MCP server.
+
+## When to Capture Tasks
+
+- `TODO:` and `FIXME:` comments in code that won't be addressed in the current session
+- Technical debt items noted during code review
+- Follow-up research items (e.g., "investigate why X behaves like Y")
+- Dependency updates to schedule
+- Post-session action items from architectural decisions
+
+## Task Format
+
+- **Title**: Concise, action-oriented (starts with a verb)
+- **Note**: Include file path, line number, and context for code-related tasks
+- **Project**: Match to an existing project if obvious; otherwise route to inbox
+- **Defer date**: Set only if genuinely time-sensitive
+
+## Workflow
+
+1. Check if a similar task already exists before creating a new one
+2. Route to inbox if project assignment is unclear
+3. Keep titles short and scannable — put detail in the note field
+
+## Avoid
+
+- Creating duplicate tasks for items already tracked in OmniFocus
+- Overly granular tasks that don't need tracking outside the current session
+- Capturing items that will be addressed immediately

--- a/dot_claude/agents/python-dev.md
+++ b/dot_claude/agents/python-dev.md
@@ -1,0 +1,40 @@
+---
+name: python-dev
+description: Python development specialist. Use for Python code review, formatting, linting, type checking, and testing tasks.
+---
+
+Specialist for Python development tasks.
+
+## Code Style
+
+- Follow PEP 8; use `black` for formatting and `isort` for import order
+- Type annotations required on all public functions and methods
+- Prefer `pathlib.Path` over `os.path`
+- Use `dataclasses` or `pydantic` for structured data
+
+## Formatting Order
+
+Always run in this sequence:
+1. `isort .`
+2. `black .`
+
+## Linting & Type Checking
+
+3. `ruff check .` — covers pyflakes, pycodestyle, isort rules, and more
+4. `mypy .` — respects `mypy.ini` or `pyproject.toml [tool.mypy]`
+5. `basedpyright` — if configured in the project
+
+## Testing
+
+- `pytest` — respects `pyproject.toml [tool.pytest.ini_options]` or `pytest.ini`
+- `pytest --cov` if coverage is configured
+- Use `pytest-asyncio` for async tests
+
+## Config File Priority
+
+Check for config in this order:
+1. `pyproject.toml`
+2. `setup.cfg`
+3. Standalone config files (`mypy.ini`, `ruff.toml`, `.flake8`)
+
+Always verify which config files exist before running tools.

--- a/dot_claude/agents/spell-check.md
+++ b/dot_claude/agents/spell-check.md
@@ -1,0 +1,33 @@
+---
+name: spell-check
+description: Checks spelling in modified files before committing. Covers documentation, code comments, docstrings, and commit messages. Use before creating any commit.
+---
+
+Check spelling across files changed in the current working tree.
+
+## Tool Priority
+
+1. `typos` — preferred; fast, low false-positives
+2. `codespell` — fallback
+3. `aspell` — interactive fallback for prose-heavy documents
+
+## Scope
+
+Run against files from `git diff --name-only`:
+- Documentation: `*.md`, `*.rst`, `*.txt`
+- Code comments and docstrings
+- Commit messages
+- String literals where appropriate
+
+## Exclusions
+
+Intentionally ignore:
+- Variable names, function names, and identifiers
+- API names, library names, and technical terms
+- URLs and hex values
+- Short abbreviations common in the codebase
+
+## Reporting
+
+- Report errors with file:line:column and suggested corrections
+- Only mark complete when all issues are resolved or explicitly suppressed


### PR DESCRIPTION
Converts the three prose subagent descriptions in CLAUDE.md into proper
~/.claude/agents/ markdown files, and adds eight new specialised agents
covering the full toolchain:

Converted from CLAUDE.md:
- cicd-monitor: GitHub/GitLab CI pipeline monitoring
- lint-test: CI-matched linting and testing before commit
- spell-check: Spelling checks on modified files before commit

New agents:
- go-dev: golangci-lint, gofumpt, go test, go mod management
- python-dev: isort, black, ruff, mypy, pytest workflow
- chezmoi: dotfiles template editing, validation, apply workflow
- github-pr: gh CLI, PR description format, Claude App setup
- k8s: kubectl, kustomize, talosctl operations
- obsidian: Obsidian vault note capture and search (via MCP)
- omnifocus: OmniFocus task capture (via MCP)
- incident-response: incident.io, o11y-analysis-tools, Jira/GitLab
  coordination — gated to cobrien username via chezmoi template

Updates CLAUDE.md Subagents section to a concise index pointing to the
agent files, removing the now-redundant implementation prose.

https://claude.ai/code/session_01PRcBTxRHhtYRuArseKLrG8