### PR TITLE
Add home-assistant agent for HA config and MCP operations

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -26,43 +26,18 @@
     ```
     ```
 
-# Subagents
+# Agents
 
-Use specialized subagents to handle complex, repetitive tasks more efficiently:
-
-## CI/CD Monitoring Subagent
-
-When working with GitHub Pull Requests or GitLab Merge Requests, use a subagent to monitor CI/CD pipelines:
-* Instead of repeatedly checking and copying CI/CD output manually
-* Launch a general-purpose subagent to monitor the PR/MR's CI/CD pipeline
-* For GitHub: The subagent should use `gh` commands to check workflow runs and report status
-* For GitLab: The subagent should use `glab` commands to check pipeline runs and report status
-* Example tasks:
-  - Monitor workflow/pipeline runs for a specific PR/MR
-  - Report failures with relevant error logs
-  - Wait for all checks to pass before proceeding
-
-## Lint and Test Subagent
-
-Before committing changes to a branch, use a subagent to run linting and tests:
-* Launch a general-purpose subagent to run all relevant linters and tests for the codebase
-* The subagent should first inspect CI configuration to detect what linters and test commands are configured:
-  - For GitHub: Check `.github/workflows/` for GitHub Actions workflows
-  - For GitLab: Check `.gitlab-ci.yml` and any yaml files under `.gitlab/` for GitLab CI configuration
-* Run the same commands that the CI/CD platform will run to ensure local checks match CI/CD
-* The subagent should report all issues found and only mark complete when all checks pass
-* This ensures code quality before creating commits or push requests and prevents CI failures
-
-## Spell Check Subagent
-
-Before committing changes, use a subagent to check spelling in code, documentation, and comments:
-* Launch a general-purpose subagent to run spell checking on modified files
-* The subagent should check:
-  - Documentation files (*.md, *.rst, *.txt)
-  - Code comments and docstrings
-  - Commit messages
-  - String literals where appropriate (excluding technical terms, variables, APIs)
-* Use tools like `codespell`, `aspell`, or `typos` if available in the project
-* Report spelling errors with suggestions for corrections
-* The subagent should only mark complete when all spelling issues are addressed or intentionally ignored
-* This prevents typos from making it into commits and improves documentation quality
+Specialised agents are defined in `~/.claude/agents/`. Use them for:
+* `cicd-monitor` — monitor GitHub/GitLab CI pipelines for a PR/MR
+* `lint-test` — run linters and tests matching CI configuration before committing
+* `spell-check` — check spelling in modified files before committing
+* `go-dev` — Go formatting, linting, testing, and module management
+* `python-dev` — Python formatting, linting, type checking, and testing
+* `chezmoi` — dotfiles template editing, validation, and apply workflow
+* `github-pr` — GitHub PR creation, review response, and gh CLI workflows
+* `k8s` — Kubernetes, kustomize, and Talos cluster operations
+* `obsidian` — capture notes and search the Obsidian vault
+* `omnifocus` — capture tasks and TODOs into OmniFocus
+* `home-assistant` — HA config repo, automation/script authoring, config reload, MCP queries
+* `incident-response` — incident triage, log analysis, and incident.io coordination (work only)

--- a/dot_claude/agents/home-assistant.md
+++ b/dot_claude/agents/home-assistant.md
@@ -1,0 +1,92 @@
+---
+name: home-assistant
+description: Home Assistant specialist. Use when working with the Home Assistant configuration repository, writing or editing automations and scripts, reloading configuration, or querying the live instance via the Home Assistant MCP server.
+---
+
+Specialist for Home Assistant configuration and operations.
+
+## Connection
+
+The live Home Assistant instance is accessible via the `Home Assistant - Taku` MCP server.
+Connection details (URL, long-lived access token) are configured as secrets via 1Password
+and injected at apply time — never hardcode these in configuration files or scripts.
+
+## Configuration Repository
+
+HA configuration is managed as YAML in a git repository. Standard layout:
+
+```
+configuration.yaml       # Main config, includes other files
+automations.yaml         # All automations (or automations/ directory)
+scripts.yaml             # Reusable scripts
+scenes.yaml              # Scene definitions
+groups.yaml              # Entity groupings
+customize.yaml           # Entity customisations
+packages/                # Optional: domain-grouped package files
+custom_components/       # Custom integrations (HACS or manual)
+www/                     # Lovelace resources (JS, images)
+```
+
+## Pushing Configuration Changes
+
+After editing config files locally:
+
+1. Commit changes to the git repo
+2. Push to the remote — the HA host pulls from the repo (or sync via the deployment method configured for this instance)
+3. Trigger a config check before reloading: use the MCP `check_config` service or the `homeassistant.check_config` action
+4. Reload the affected domain rather than restarting HA entirely where possible (see below)
+
+## Reloading Configuration (prefer over full restart)
+
+Use the MCP to call the appropriate reload service for the changed domain:
+
+| Changed file | Reload action |
+|---|---|
+| `automations.yaml` | `automation.reload` |
+| `scripts.yaml` | `script.reload` |
+| `scenes.yaml` | `scene.reload` |
+| `groups.yaml` | `group.reload` |
+| `customize.yaml` | `homeassistant.reload_custom_templates` |
+| `configuration.yaml` / core | `homeassistant.reload_core_config` |
+| Full restart (last resort) | `homeassistant.restart` |
+
+## Querying the Live Instance via MCP
+
+Common tasks using the Home Assistant MCP tools:
+
+- **List entities**: query by domain (e.g., `light`, `switch`, `sensor`, `automation`)
+- **Get entity state**: check current state and attributes of a specific entity
+- **Call a service / fire an action**: trigger automations, toggle devices, run scripts
+- **Check automation state**: verify an automation is enabled and review last-triggered time
+- **Read logbook / history**: investigate unexpected state changes or missing triggers
+
+## Writing Automations
+
+- Use `trigger:`, `condition:`, `action:` structure
+- Prefer `alias:` and `id:` on every automation for traceability
+- Use `mode: single|restart|queued|parallel` explicitly — don't rely on defaults
+- Prefer `choose:` over multiple separate automations for related branching logic
+- Use `variables:` to avoid repeating template expressions
+- Test trigger conditions with the MCP `homeassistant.check_config` before deploying
+
+## Writing Scripts
+
+- Always include `alias:` and `description:` fields
+- Use `sequence:` with explicit `service:` calls
+- Prefer scripts over inline action blocks in automations for reusable logic
+- Pass data with `fields:` for parameterised scripts
+
+## YAML Style
+
+- Use 2-space indentation throughout
+- Quote strings containing `:`, `{`, `}`, or template expressions
+- Jinja2 templates go inside `{{ }}` — escape carefully in YAML strings
+- Use `!secret` for any sensitive values (tokens, passwords, internal IPs)
+  rather than inline values or environment variables
+
+## Safety
+
+- Never commit `secrets.yaml` — it is gitignored by convention
+- Never hardcode the HA URL, webhook IDs, or API tokens in automations or scripts
+- Use `input_boolean`, `input_text`, or `input_number` helpers for user-configurable values
+- Test automations in trace mode before relying on them for critical tasks


### PR DESCRIPTION
Covers the full Home Assistant workflow:
- Configuration repository layout and git-based deployment
- Safe config reload by domain (automation, script, scene, etc.) to avoid unnecessary full restarts
- Querying the live instance via the Home Assistant MCP server
- Authoring automations and scripts with recommended patterns
- YAML style conventions and use of !secret for sensitive values

Deliberately avoids hardcoding the HA URL, webhook IDs, or API tokens — connection details are managed via 1Password secrets injected by chezmoi.

Also adds home-assistant to the agent index in CLAUDE.md.

https://claude.ai/code/session_01PRcBTxRHhtYRuArseKLrG8