### PR TITLE
Replace $HOME with ~ in ghostty config path

### DIFF
--- a/Library/private_Application Support/com.mitchellh.ghostty/config
+++ b/Library/private_Application Support/com.mitchellh.ghostty/config
@@ -1,2 +1,2 @@
 # Per https://ghostty.org/docs/config#splitting-into-multiple-files
-config-file = $HOME/.config/ghostty/config
+config-file = ~/.config/ghostty/config


### PR DESCRIPTION
## Summary
Updated the ghostty configuration file path to use the tilde (`~`) shorthand instead of the `$HOME` environment variable.

## Changes
- Replaced `$HOME/.config/ghostty/config` with `~/.config/ghostty/config` in the ghostty config file reference

## Details
This change simplifies the path syntax by using the shell's tilde expansion (`~`), which is more concise and commonly used in configuration files. Both forms are functionally equivalent, as `~` expands to the user's home directory just like `$HOME`.

https://claude.ai/code/session_011bZDn5gTGuUrYgykPaXahc