### PR TITLE
Update GitLab credentials reference to use item IDs

### DIFF
--- a/dot_netrc
+++ b/dot_netrc
@@ -1,4 +1,4 @@
 # Only to take effect on a work machine
 {{- if eq .chezmoi.username "cobrien" }}
-machine gitlab.com login {{- (onepasswordDetailsFields "op://Crusoe/Employee/GitLab Personal Access Token").username.value }} password {{- onepasswordDocument "op://Crusoe/Employee/GitLab Personal Access Token" -}}
+machine gitlab.com login {{- (onepasswordDetailsFields "lrqnefejh7v23v54lvajoa4x2q" "" "FUJ74MTVQVCN5DXVK4PSF5HKU4").username.value }} password {{- onepasswordDocument "lrqnefejh7v23v54lvajoa4x2q" "" "FUJ74MTVQVCN5DXVK4PSF5HKU4" -}}
 {{- end }}


### PR DESCRIPTION
## Summary
Updated the `.netrc` configuration to reference GitLab credentials using 1Password item IDs instead of human-readable paths.

## Changes
- Replaced 1Password path references (`op://Crusoe/Employee/GitLab Personal Access Token`) with direct item IDs (`lrqnefejh7v23v54lvajoa4x2q`) and vault IDs (`FUJ74MTVQVCN5DXVK4PSF5HKU4`)
- Updated both `onepasswordDetailsFields` and `onepasswordDocument` function calls to use the new reference format

## Details
This change updates the 1Password integration to use stable item identifiers instead of path-based references, which can be more reliable for automated credential retrieval in chezmoi configurations.

https://claude.ai/code/session_013N7qmDuBcQAeHVXK4gBXQT