### PR TITLE
Remove GitLab and Context7 MCP server configurations

### DIFF
--- a/dot_claude/mcp-servers-work.json.tmpl
+++ b/dot_claude/mcp-servers-work.json.tmpl
@@ -6,21 +6,11 @@
     "INCIDENT_IO_API_KEY": "{{ (onepasswordDetailsFields "jqnzasyqfhkqf7iza5vspjwboa").credential.value }}"
   }
 },
-"GitLab": {
-  "type": "http",
-  "url": "https://gitlab.com/api/v4/mcp"
-},
 "obsidian-mcp-tools": {
   "command": "/Users/{{- .chezmoi.username -}}/Documents/Multiverse/.obsidian/plugins/mcp-tools/bin/mcp-server",
   "env": {
     "OBSIDIAN_API_KEY": "{{- (onepasswordDetailsFields "xe6ncd3wlggzxt6lq7zv3mduly").credential.value }}"
   }
-},
-"context7": {
-  "type": "http",
-  "url": "https://mcp.context7.com/mcp",
-  "oauthClientId": "CONTEXT7_API_KEY",
-  "oauthClientSecret": "{{- (onepasswordDetailsFields "3c2h6vl24g4nb3qfwmaovqf7ze").credential.value }}"
 },
 "omnifocus": {
   "command": "/opt/homebrew/bin/mcp-omnifocus",


### PR DESCRIPTION
## Summary
This change removes two unused MCP server configurations from the Claude configuration template.

## Key Changes
- Removed GitLab MCP server configuration (HTTP-based endpoint)
- Removed Context7 MCP server configuration (OAuth-based endpoint with API key credential)

## Details
These server configurations are no longer needed in the MCP servers setup. The removal simplifies the configuration file by eliminating unused integrations while keeping the active servers (incident-io, obsidian-mcp-tools, and omnifocus).

https://claude.ai/code/session_012rSQUYiVRHJyWgpBFVjoGg