### PR TITLE
Enforce Python venv via mkvirtualenv for all Python operations

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -10,6 +10,7 @@
 # Testing
 * Always write unittests when writing languages such as Go or Python
 * Always run linters, `golangci-lint` and `go fmt` for Golang , `black`, `ruff` for Python
+* Always run Python operations (linting, testing, package installs) inside a virtualenv managed via `mkvirtualenv` (virtualenvwrapper); never use system Python
 
 # Workflow
 * When working on Github repositories under github.com/conallob , always install Claude App and Claude Github Actions

--- a/dot_claude/agents/python-dev.md
+++ b/dot_claude/agents/python-dev.md
@@ -5,6 +5,23 @@ description: Python development specialist. Use for Python code review, formatti
 
 Specialist for Python development tasks.
 
+## Virtual Environment
+
+Always use a virtualenv managed via `virtualenvwrapper` (`mkvirtualenv`):
+
+- **Before any Python operation**, ensure a virtualenv is active
+- If no virtualenv is active, create or activate one:
+  ```bash
+  # Create a new venv (first time)
+  mkvirtualenv <project-name>
+
+  # Or activate an existing one
+  workon <project-name>
+  ```
+- Derive the project name from the project directory or `pyproject.toml` `[project] name`
+- All `pip install`, `pytest`, `black`, `ruff`, `mypy`, etc. must run inside the active venv
+- Never install packages into the system Python
+
 ## Code Style
 
 - Follow PEP 8; use `black` for formatting and `isort` for import order


### PR DESCRIPTION
## Summary

- Added a `## Virtual Environment` section to `dot_claude/agents/python-dev.md` requiring all Python operations to run inside a `virtualenvwrapper`-managed venv
- Added a corresponding rule to `dot_claude/CLAUDE.md` so the requirement applies globally, not just when the `python-dev` agent is explicitly invoked
- Never install packages into system Python

## Original Prompt

```
Let's update @dot_claude/CLAUDE.md and the appropriate agent to ensure that any python operations are all performed in a venv, managed via `mkvirtualenv`
```