### PR TITLE
Add GitLab API token configuration to Claude settings

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -10,6 +10,10 @@
     {{- /* Git Commit Commands */}}
     "commit-commands@claude-plugins-official": true
   },
+  "env": {
+    {{- /* GitLab API token from work 1Password account */}}
+    "GITLAB_TOKEN": "{{ (onepasswordDetailsFields "zvmzgcfpmw33ttzrw4ureqxtim" "" "FUJ74MTVQVCN5DXVK4PSF5HKU4").credential.value }}"
+  },
   "hooks": {
     {{- /* Native system notifications when Claude is waiting for input */}}
     "Notification": [

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -10,10 +10,12 @@
     {{- /* Git Commit Commands */}}
     "commit-commands@claude-plugins-official": true
   },
+{{- if eq .chezmoi.username "cobrien" }}
   "env": {
     {{- /* GitLab API token from work 1Password account */}}
     "GITLAB_TOKEN": "{{ (onepasswordDetailsFields "zvmzgcfpmw33ttzrw4ureqxtim" "" "FUJ74MTVQVCN5DXVK4PSF5HKU4").credential.value }}"
   },
+{{- end }}
   "hooks": {
     {{- /* Native system notifications when Claude is waiting for input */}}
     "Notification": [

--- a/dot_config/chezmoi/chezmoi.toml.tmpl
+++ b/dot_config/chezmoi/chezmoi.toml.tmpl
@@ -3,4 +3,4 @@
 [onepassword]
   command = "op"
   mode = "account"
-	account = "conall@taku.ie"
+	account = {{ if eq .chezmoi.username "cobrien" }}"FUJ74MTVQVCN5DXVK4PSF5HKU4"{{ else }}"conall@taku.ie"{{ end }}

--- a/dot_config/chezmoi/chezmoi.toml.tmpl
+++ b/dot_config/chezmoi/chezmoi.toml.tmpl
@@ -3,4 +3,4 @@
 [onepassword]
   command = "op"
   mode = "account"
-	account = {{ if eq .chezmoi.username "cobrien" }}"FUJ74MTVQVCN5DXVK4PSF5HKU4"{{ else }}"conall@taku.ie"{{ end }}
+	account = {{ if eq .chezmoi.username "cobrien" }}"FUJ74MTVQVCN5DXVK4PSF5HKU4"{{ else }}"ZVA4BFN3HZDBJM2HNAKREAS22M"{{ end }}


### PR DESCRIPTION
## Summary

- Added `GITLAB_TOKEN` env var to `dot_claude/settings.json.tmpl`, scoped to the `cobrien` username via a chezmoi conditional
- Token fetched from 1Password item `zvmzgcfpmw33ttzrw4ureqxtim` in the work account (`FUJ74MTVQVCN5DXVK4PSF5HKU4`)
- Updated `chezmoi.toml.tmpl` to conditionally set the active 1Password account: work account (`FUJ74MTVQVCN5DXVK4PSF5HKU4`) for `cobrien`, personal account (`ZVA4BFN3HZDBJM2HNAKREAS22M`) otherwise — using opaque account IDs throughout to avoid embedding email addresses

## Original Prompt

```
Set an environmental variable in @dot_claude , using chezmoi templating for integration with 1Password

`GITLAB_TOKEN` variable should be set with the credential of 1Password item `zvmzgcfpmw33ttzrw4ureqxtim`, which is stored in my work account id
```

https://claude.ai/code/session_01EpG6ZZtd68WTZ6bWyuPwe5