### PR TITLE
Remove Test Plan section from PR/MR description templates

### DIFF
--- a/dot_claude/agents/github-pr.md
+++ b/dot_claude/agents/github-pr.md
@@ -19,9 +19,6 @@ Always structure PR descriptions as:
 ## Summary
 - <bullet points describing changes>
 
-## Test Plan
-- [ ] <what was tested>
-
 ## Original Prompt
 
 ```
@@ -30,6 +27,8 @@ Always structure PR descriptions as:
 
 <session URL>
 ```
+
+Do **not** include a Test Plan section in PR descriptions — test plans belong in commits, code comments, or linked issues, not in the PR description itself.
 
 - Keep PR title under 70 characters
 - `gh pr create --title "..." --body "$(cat <<'EOF' ... EOF)"`

--- a/dot_claude/agents/github-pr.md
+++ b/dot_claude/agents/github-pr.md
@@ -19,19 +19,18 @@ Always structure PR descriptions as:
 ## Summary
 - <bullet points describing changes>
 
-Co-Authored-By: Claude Code + Claude {{ model }}
-
-## Original Prompt
+## AI
+Co-Authored-By: Claude Code + Claude <model>, with the original prompt:
 
 ```
 <original user prompt here>
 ```
 
-<session URL>
+https://claude.ai/session/<session-id>
 ```
 
 - Do **not** include a Test Plan section — test plans belong in commits, code comments, or linked issues, not in the PR description.
-- `{{ model }}` should be replaced with the actual Claude model name (e.g. `claude-sonnet-4-6`).
+- Replace `<model>` with the actual Claude model name (e.g. `claude-sonnet-4-6`).
 
 - Keep PR title under 70 characters
 - `gh pr create --title "..." --body "$(cat <<'EOF' ... EOF)"`

--- a/dot_claude/agents/github-pr.md
+++ b/dot_claude/agents/github-pr.md
@@ -19,6 +19,8 @@ Always structure PR descriptions as:
 ## Summary
 - <bullet points describing changes>
 
+Co-Authored-By: Claude Code + Claude {{ model }}
+
 ## Original Prompt
 
 ```
@@ -28,7 +30,8 @@ Always structure PR descriptions as:
 <session URL>
 ```
 
-Do **not** include a Test Plan section in PR descriptions — test plans belong in commits, code comments, or linked issues, not in the PR description itself.
+- Do **not** include a Test Plan section — test plans belong in commits, code comments, or linked issues, not in the PR description.
+- `{{ model }}` should be replaced with the actual Claude model name (e.g. `claude-sonnet-4-6`).
 
 - Keep PR title under 70 characters
 - `gh pr create --title "..." --body "$(cat <<'EOF' ... EOF)"`

--- a/dot_claude/agents/gitlab-mr.md
+++ b/dot_claude/agents/gitlab-mr.md
@@ -13,19 +13,22 @@ Always structure MR descriptions as:
 ## Summary
 - <bullet points describing changes>
 
-Co-Authored-By: Claude Code + Claude {{ model }}
+## Linked Jira Issue
+- <link to one or more Jira issues>
 
-## Original Prompt
+## AI
+Co-Authored-By: Claude Code + Claude <model>, with the original prompt:
 
 ```
 <original user prompt here>
 ```
 
-<session URL>
+https://claude.ai/session/<session-id>
 ```
 
 - Do **not** include a Test Plan section — test plans belong in commits, code comments, or linked issues, not in the MR description.
-- `{{ model }}` should be replaced with the actual Claude model name (e.g. `claude-sonnet-4-6`).
+- Always include one or more Jira issue links in the `Linked Jira Issue` section.
+- Replace `<model>` with the actual Claude model name (e.g. `claude-sonnet-4-6`).
 
 - Keep MR title under 70 characters
 - `glab mr create --title "..." --description "$(cat <<'EOF' ... EOF)"`

--- a/dot_claude/agents/gitlab-mr.md
+++ b/dot_claude/agents/gitlab-mr.md
@@ -13,9 +13,6 @@ Always structure MR descriptions as:
 ## Summary
 - <bullet points describing changes>
 
-## Test Plan
-- [ ] <what was tested>
-
 ## Original Prompt
 
 ```
@@ -24,6 +21,8 @@ Always structure MR descriptions as:
 
 <session URL>
 ```
+
+Do **not** include a Test Plan section in MR descriptions — test plans belong in commits, code comments, or linked issues, not in the MR description itself.
 
 - Keep MR title under 70 characters
 - `glab mr create --title "..." --description "$(cat <<'EOF' ... EOF)"`

--- a/dot_claude/agents/gitlab-mr.md
+++ b/dot_claude/agents/gitlab-mr.md
@@ -13,6 +13,8 @@ Always structure MR descriptions as:
 ## Summary
 - <bullet points describing changes>
 
+Co-Authored-By: Claude Code + Claude {{ model }}
+
 ## Original Prompt
 
 ```
@@ -22,7 +24,8 @@ Always structure MR descriptions as:
 <session URL>
 ```
 
-Do **not** include a Test Plan section in MR descriptions — test plans belong in commits, code comments, or linked issues, not in the MR description itself.
+- Do **not** include a Test Plan section — test plans belong in commits, code comments, or linked issues, not in the MR description.
+- `{{ model }}` should be replaced with the actual Claude model name (e.g. `claude-sonnet-4-6`).
 
 - Keep MR title under 70 characters
 - `glab mr create --title "..." --description "$(cat <<'EOF' ... EOF)"`

--- a/dot_claude/agents/gitlab-mr.md
+++ b/dot_claude/agents/gitlab-mr.md
@@ -27,7 +27,7 @@ https://claude.ai/session/<session-id>
 ```
 
 - Do **not** include a Test Plan section — test plans belong in commits, code comments, or linked issues, not in the MR description.
-- Always include one or more Jira issue links in the `Linked Jira Issue` section.
+- Always include one or more Jira issue links in the `Linked Jira Issue` section. The Jira issue key is often embedded in the branch name (e.g. `feat/PROJ-1234-some-description` → `PROJ-1234`); extract it from there if not otherwise known.
 - Replace `<model>` with the actual Claude model name (e.g. `claude-sonnet-4-6`).
 
 - Keep MR title under 70 characters


### PR DESCRIPTION
## Summary
Updated GitHub PR and GitLab MR description templates to remove the Test Plan section and clarify where test information should be documented instead.

## Changes
- Removed the `## Test Plan` section template from both `github-pr.md` and `gitlab-mr.md`
- Added explicit guidance that test plans belong in commits, code comments, or linked issues rather than in PR/MR descriptions
- This keeps PR/MR descriptions focused on what changed and why, not how it was tested

## Rationale
Test plans are implementation details that clutter PR/MR descriptions. They're better suited for:
- Commit messages (for specific test coverage)
- Code comments (for complex test scenarios)
- Linked issues or test tracking systems (for comprehensive test documentation)

This change encourages cleaner, more focused PR/MR descriptions that communicate the intent and scope of changes to reviewers.

https://claude.ai/code/session_01DQdYezP1YUkzwN5RDQXLYq