### PR TITLE
Remove UltiSnips and Windsurf AI plugin dependencies

### DIFF
--- a/dot_vim/README.md
+++ b/dot_vim/README.md
@@ -7,7 +7,7 @@ A comprehensive, modern Vim configuration optimized for Go and Python developmen
 ### Core Capabilities
 - **LSP Support**: Full Language Server Protocol integration with vim-lsp
 - **Auto-completion**: Async completion with asyncomplete.vim
-- **AI Assistance**: Claude and Windsurf AI integration for code assistance
+- **AI Assistance**: Claude AI integration for code assistance
 - **Git Integration**: Full GitHub and GitLab support with fugitive
 - **Fuzzy Finding**: Fast file navigation with fzf
 - **Linting & Formatting**: Comprehensive linting with ALE and auto-formatting on save
@@ -152,8 +152,6 @@ The leader key is set to `,` (comma)
 | `<Tab>` | Next completion item |
 | `<S-Tab>` | Previous completion item |
 | `<CR>` | Accept completion |
-| `<C-j>` | Expand/jump forward snippet |
-| `<C-k>` | Jump backward snippet |
 
 ### Window Navigation
 

--- a/dot_vim/vimrc
+++ b/dot_vim/vimrc
@@ -68,10 +68,8 @@ Plug 'prabirshrestha/asyncomplete.vim'              " Async completion
 Plug 'prabirshrestha/asyncomplete-lsp.vim'          " LSP source for asyncomplete
 Plug 'dense-analysis/ale'                           " Linting and fixing
 Plug 'honza/vim-snippets'                           " Snippet collection
-Plug 'SirVer/ultisnips'                             " Snippet engine
 
 " --- AI Assistance ---
-Plug 'Exafunction/windsurf.vim', { 'branch': 'main' } " Windsurf AI (keeping existing)
 Plug 'madox2/vim-ai'                                " Claude/OpenAI integration
 
 " --- Git Integration ---
@@ -241,13 +239,6 @@ let g:ale_fix_on_save = 1
 inoremap <expr> <Tab>   pumvisible() ? "\<C-n>" : "\<Tab>"
 inoremap <expr> <S-Tab> pumvisible() ? "\<C-p>" : "\<S-Tab>"
 inoremap <expr> <CR>    pumvisible() ? asyncomplete#close_popup() : "\<CR>"
-
-" ============================================================================
-" UltiSnips Configuration
-" ============================================================================
-let g:UltiSnipsExpandTrigger="<c-j>"
-let g:UltiSnipsJumpForwardTrigger="<c-j>"
-let g:UltiSnipsJumpBackwardTrigger="<c-k>"
 
 " ============================================================================
 " AI Integration (vim-ai for Claude)


### PR DESCRIPTION
## Summary
This PR removes two unused plugin dependencies from the Vim configuration: UltiSnips snippet engine and Windsurf AI integration. These plugins are being replaced by simpler, more focused alternatives.

## Key Changes
- **Removed UltiSnips plugin**: Deleted the `SirVer/ultisnips` plugin declaration and all associated configuration (keybindings for expand/jump triggers)
- **Removed Windsurf AI plugin**: Deleted the `Exafunction/windsurf.vim` plugin declaration, consolidating AI assistance to use only `vim-ai` for Claude/OpenAI integration
- **Updated documentation**: Removed references to UltiSnips keybindings (`<C-j>` and `<C-k>`) from the README and updated the AI Assistance description to reflect Claude-only integration

## Implementation Details
- The snippet functionality previously provided by UltiSnips is no longer needed in this configuration
- AI assistance is now exclusively handled by the `vim-ai` plugin for Claude/OpenAI integration, simplifying the toolchain
- All configuration sections and keybindings related to these plugins have been cleanly removed

https://claude.ai/code/session_01SFRD6rDYuhjznYbeHivQux