### PR TITLE
Refactor .netrc to use private template file

### DIFF
--- a/dot_netrc
+++ b/dot_netrc
@@ -1,4 +1,0 @@
-# Only to take effect on a work machine
-{{- if eq .chezmoi.username "cobrien" }}
-machine gitlab.com login {{- (onepasswordDetailsFields "lrqnefejh7v23v54lvajoa4x2q" "" "FUJ74MTVQVCN5DXVK4PSF5HKU4").username.value }} password {{- onepasswordDocument "lrqnefejh7v23v54lvajoa4x2q" "" "FUJ74MTVQVCN5DXVK4PSF5HKU4" -}}
-{{- end }}

--- a/private_dot_netrc.tmpl
+++ b/private_dot_netrc.tmpl
@@ -1,0 +1,3 @@
+{{- if eq .chezmoi.username "cobrien" }}
+machine gitlab.com login {{ (onepasswordDetailsFields "lrqnefejh7v23v54lvajoa4x2q" "" "FUJ74MTVQVCN5DXVK4PSF5HKU4").username.value }} password {{ onepasswordDocument "lrqnefejh7v23v54lvajoa4x2q" "" "FUJ74MTVQVCN5DXVK4PSF5HKU4" -}}
+{{ end -}}


### PR DESCRIPTION
## Summary
Refactored the `.netrc` configuration file to use chezmoi's private template naming convention for improved security and clarity.

## Changes
- Removed `dot_netrc` file
- Added `private_dot_netrc.tmpl` to replace it with proper private file permissions (0600)
- Cleaned up template formatting:
  - Removed unnecessary comment about work machine (intent is clear from conditional)
  - Improved whitespace handling with `{{-` and `-}}` trim markers for cleaner template rendering
  - Standardized spacing around template expressions

## Implementation Details
The new `private_dot_netrc.tmpl` file:
- Uses the `private_` prefix to ensure the rendered `.netrc` file has secure permissions (0600)
- Maintains the same 1Password integration for GitLab credentials
- Preserves the username-based conditional to only apply on the work machine (`cobrien`)
- Follows chezmoi naming conventions as documented in the repository

This change improves security by explicitly marking the file as private and makes the template intent clearer through proper naming.

https://claude.ai/code/session_01AbszTafGB32ZQWRjRLuBTZ