### PR TITLE
Rename stl skill to fabricate and expand documentation

### DIFF
--- a/dot_claude/skills/fabricate/SKILL.md
+++ b/dot_claude/skills/fabricate/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: stl
+name: fabricate
 description: |
   Design objects for fabrication on the Snapmaker 2 A350T — a 3-in-1 machine with
   3D printing (dual nozzle head, official enclosure), laser cutting/engraving (1.6 W
@@ -10,7 +10,7 @@ description: |
 user-invocable: true
 ---
 
-# /stl — Design for the Snapmaker 2 A350T
+# /fabricate — Design for the Snapmaker 2 A350T
 
 Design an object for fabrication on the Snapmaker 2 A350T. The machine is a
 **3-in-1** platform; the first step is always confirming which modality to use.
@@ -25,6 +25,14 @@ The A350T is equipped with:
 - **10 W laser module** (high-power upgrade, thicker material cutting)
 - **CNC carving module**
 - **Rotary module** — assembled; 4th-axis (A-axis) capability for laser and CNC; **not yet calibrated/configured**
+
+### Environment Sensors
+
+Two Home Assistant sensors monitor the workshop environment:
+- **Inside enclosure**: `sensor.snapmaker_enclosure` — temperature + humidity inside the official enclosure
+- **Outside enclosure**: `sensor.workshop_sensor` — ambient workshop temperature + humidity
+
+Query these via the `home-assistant` agent when evaluating print conditions (e.g. ABS/ASA humidity sensitivity, enclosure warm-up state).
 
 ---
 
@@ -63,6 +71,14 @@ The A350T is equipped with:
 - Layer adhesion is weakest along Z; orient load paths in X/Y
 
 **Dual nozzle use cases:** material changes between prints without manual re-threading (e.g. PLA then TPU). Only one nozzle is active at a time — true simultaneous multi-material is not supported. Note in design which bodies use which nozzle.
+
+### Filament Management
+
+- **Storage**: all spools are stored in individual zip-lock bags in the workshop space alongside the Snapmaker
+- **Drying**: the **EIBOS Polyphemus Dryer** is available for moisture-sensitive filaments (ABS, ASA, Nylon, TPU); dry before printing if a spool has been open or humidity has been elevated
+- **Tracking**: every spool has a **SimplyPrint.io RFID tag** recording material type, colour, temperature settings, and weight remaining — consult SimplyPrint before selecting a spool to confirm available material
+
+When recommending a material, note whether it should be dried first (check `sensor.workshop_sensor` humidity) and confirm weight remaining via SimplyPrint RFID data.
 
 ---
 
@@ -167,6 +183,8 @@ the vector geometry. Separate layers: `engrave-fill`, `engrave-outline`, `score`
 - [ ] Kerf compensation added (laser)?
 - [ ] Dog-bone fillets on internal CNC corners?
 - [ ] Rotary files flagged as uncalibrated if applicable?
+- [ ] Filament: weight available confirmed via SimplyPrint RFID?
+- [ ] Filament: drying needed based on workshop humidity?
 
 ### 6. Fabrication notes
 End the response with a concise **Fabrication Settings** block:
@@ -174,6 +192,7 @@ End the response with a concise **Fabrication Settings** block:
 - Material + temps (3D) or feed/speed (CNC) or power/speed (laser)
 - Layer height / pass depth
 - Supports or fixturing needed
+- Filament spool status (colour, weight remaining, dry/wet)
 - Estimated time (rough)
 
 ---


### PR DESCRIPTION
## Summary

Renamed the `stl` skill to `fabricate` to better reflect its broader scope beyond just 3D printing, and significantly expanded the skill documentation with practical workshop information about environment monitoring, filament management, and fabrication checklists.

## Key Changes

- **Skill rename**: `stl` → `fabricate` (updated in SKILL.md filename and all references)
- **Environment monitoring**: Added documentation for Home Assistant sensors tracking enclosure and workshop conditions (temperature/humidity)
- **Filament management**: Documented storage practices, drying requirements (EIBOS Polyphemus Dryer), and RFID tracking via SimplyPrint.io
- **Enhanced checklists**: Added filament-specific checks to the pre-fabrication checklist:
  - Weight availability confirmation via SimplyPrint RFID
  - Drying needs assessment based on workshop humidity
- **Fabrication notes**: Extended the Fabrication Settings block to include filament spool status (colour, weight remaining, dry/wet state)

## Implementation Details

The documentation updates provide practical guidance for:
- Querying Home Assistant sensors when evaluating print conditions (especially for humidity-sensitive materials like ABS/ASA)
- Checking filament availability and specifications before material selection
- Determining whether moisture-sensitive filaments need drying based on current workshop conditions
- Tracking filament state in fabrication notes for reproducibility and material management

These additions bridge the gap between design recommendations and actual workshop constraints, improving the skill's practical utility for fabrication planning.

https://claude.ai/code/session_01LfBHyocyb5tUor8ycrykCp