### PR TITLE
Convert Obsidian MCP server to HTTP-based configuration

### DIFF
--- a/dot_claude/mcp-servers-personal.json.tmpl
+++ b/dot_claude/mcp-servers-personal.json.tmpl
@@ -1,8 +1,8 @@
 {{- /* Personal and Third-party MCP Servers */ -}}
 "obsidian-mcp-tools": {
-  "command": "/Users/{{- .chezmoi.username -}}/Documents/Multiverse/.obsidian/plugins/mcp-tools/bin/mcp-server",
-  "env": {
-    "OBSIDIAN_API_KEY": "{{- (onepasswordDetailsFields "xe6ncd3wlggzxt6lq7zv3mduly").credential.value }}"
+  "url": "{{- (onepasswordDetailsFields "xe6ncd3wlggzxt6lq7zv3mduly").hostname.value }}",
+  "headers": {
+    "Authorization": "Bearer {{- (onepasswordDetailsFields "xe6ncd3wlggzxt6lq7zv3mduly").credential.value }}"
   }
 },
 "omnifocus": {


### PR DESCRIPTION
## Summary

Migrates the Obsidian MCP server configuration from a local command-based setup to an HTTP-based endpoint with Bearer token authentication.

## Changes

- **Configuration type**: Changed from `command` (local binary execution) to `url` (HTTP endpoint)
  - Removed local path: `/Users/{{- .chezmoi.username -}}/Documents/Multiverse/.obsidian/plugins/mcp-tools/bin/mcp-server`
  - Added HTTP endpoint URL from 1Password: `hostname` field
  
- **Authentication method**: Updated from environment variable to HTTP header
  - Removed: `OBSIDIAN_API_KEY` environment variable
  - Added: `Authorization` header with Bearer token pattern using the same 1Password `credential` field

## Implementation Details

Both configurations continue to source the API credential from the same 1Password item (`xe6ncd3wlggzxt6lq7zv3mduly`), ensuring no change to secret management. The migration enables the Obsidian MCP server to be accessed as a remote HTTP service rather than a local subprocess, which may improve reliability and allow for better separation of concerns in the Claude Desktop MCP architecture.

https://claude.ai/code/session_01VWWdRhRFzapys5bKfx9QVY