### PR TITLE
vim: interview-ready config — bug fixes, LSP/Go, snippets, REST client

### DIFF
--- a/.github/scripts/check-snippets.py
+++ b/.github/scripts/check-snippets.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Validate UltiSnips snippet file structure.
+
+Checks:
+- Every 'snippet' block has a matching 'endsnippet'
+- No nested snippet definitions
+- No stray 'endsnippet' outside a block
+
+Usage: python3 check-snippets.py <directory>
+"""
+import sys
+import pathlib
+
+
+def check_file(path: pathlib.Path) -> list[str]:
+    errors = []
+    in_snippet = False
+    current_name = None
+
+    with open(path) as f:
+        for lineno, raw in enumerate(f, 1):
+            line = raw.rstrip()
+            stripped = line.lstrip()
+
+            if stripped.startswith("snippet ") and not in_snippet:
+                in_snippet = True
+                parts = stripped.split()
+                current_name = parts[1] if len(parts) > 1 else "<unnamed>"
+
+            elif stripped == "endsnippet":
+                if not in_snippet:
+                    errors.append(
+                        f"{path}:{lineno}: stray 'endsnippet' outside snippet block"
+                    )
+                in_snippet = False
+                current_name = None
+
+            elif stripped.startswith("snippet ") and in_snippet:
+                errors.append(
+                    f"{path}:{lineno}: nested 'snippet' inside '{current_name}'"
+                )
+
+    if in_snippet:
+        errors.append(f"{path}: unclosed snippet '{current_name}' at end of file")
+
+    return errors
+
+
+def main() -> int:
+    directory = pathlib.Path(sys.argv[1]) if len(sys.argv) > 1 else pathlib.Path("dot_vim/UltiSnips")
+
+    if not directory.exists():
+        print(f"Directory not found: {directory}")
+        return 1
+
+    files = sorted(directory.glob("*.snippets"))
+    if not files:
+        print(f"No *.snippets files found in {directory}")
+        return 0
+
+    all_errors: list[str] = []
+    for path in files:
+        all_errors.extend(check_file(path))
+
+    if all_errors:
+        for error in all_errors:
+            print(f"ERROR: {error}")
+        return 1
+
+    print(f"OK: {len(files)} snippet file(s) valid ({sum(1 for f in files for _ in [None])} checked)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check-vimrc-patterns.sh
+++ b/.github/scripts/check-vimrc-patterns.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Grep-based antipattern checks for the vimrc.
+# Each check targets a class of bug that has caused real breakage in this repo.
+# Run: bash .github/scripts/check-vimrc-patterns.sh dot_vim/vimrc
+set -euo pipefail
+
+VIMRC="${1:?Usage: $0 <vimrc-path>}"
+fail=0
+
+pass() { echo "  OK"; }
+fail() { echo "  FAIL: $*"; fail=1; }
+
+# ── Check 1: unconditional clipboard= setting ─────────────────────────────────
+# 'set clipboard=unnamedplus' without a has() guard silently does nothing on vim
+# builds without +clipboard or on systems with no X11/Wayland, breaking all
+# yank/paste to the system register.
+echo "→ clipboard= must be conditional on has()"
+if grep -Pn '^set clipboard=' "$VIMRC"; then
+  fail "wrap in: if has('unnamedplus') ... elseif has('clipboard') ... endif"
+else
+  pass
+fi
+
+# ── Check 2: exists('g:loaded_*') guard antipattern ──────────────────────────
+# vim-plug's plug#end() adds plugins to &runtimepath but does not source their
+# plugin/*.vim files during vimrc execution — that happens afterward. So
+# g:loaded_<plugin> is always unset at vimrc parse time, making this guard a
+# permanent no-op. Use exists(':CommandName') == 2 or autocmd VimEnter instead.
+echo "→ exists('g:loaded_*') guard is unreliable at parse time"
+if grep -n "exists('g:loaded_" "$VIMRC"; then
+  fail "use exists(':CommandName') == 2 or autocmd VimEnter * ..."
+else
+  pass
+fi
+
+# ── Check 3: neovim-only lua calls without has('nvim') guard ─────────────────
+# 'lua vim.*' is neovim-only. In regular vim it raises an error even with
+# silent! (the error is suppressed but the Lua runtime is never available).
+# Must be inside an 'if has("nvim") ... endif' block.
+echo "→ 'lua vim.*' calls must be guarded by has('nvim')"
+if awk '
+  /if has\('"'"'nvim'"'"'\)/ { depth++ }
+  /^[[:space:]]*endif/ && depth > 0 { depth-- }
+  /lua vim\./ && depth == 0 {
+    printf "  %s:%d: lua vim.* outside has('"'"'nvim'"'"') guard\n", FILENAME, NR
+    found = 1
+  }
+  END { exit (found ? 1 : 0) }
+' "$VIMRC"; then
+  pass
+else
+  fail "wrap in: if has('nvim') ... endif"
+fi
+
+# ── Check 4: vim-ai partial configuration ────────────────────────────────────
+# vim-ai's :AI and :AIEdit commands use g:vim_ai_complete and g:vim_ai_edit
+# for their config. If only g:vim_ai_chat is set, the other two fall back to
+# the built-in OpenAI defaults and emit a startup warning when OPENAI_API_KEY
+# is not set — even if you're exclusively using the Anthropic endpoint.
+echo "→ vim-ai: all three g:vim_ai_* configs must be set together"
+if grep -q 'vim-ai' "$VIMRC"; then
+  ai_ok=1
+  for var in g:vim_ai_complete g:vim_ai_edit g:vim_ai_chat; do
+    if ! grep -q "let $var\b" "$VIMRC"; then
+      echo "  FAIL: $var not defined — causes OpenAI startup warning"
+      ai_ok=0
+      fail=1
+    fi
+  done
+  [ "$ai_ok" -eq 1 ] && pass
+else
+  echo "  OK (vim-ai not present)"
+fi
+
+# ── Check 5: Go format-on-save conflict ──────────────────────────────────────
+# If ALE has go in ale_fixers AND LspDocumentFormatSync is in BufWritePre,
+# Go files get formatted twice (ALE gofmt/goimports + gopls), causing
+# flickering and potential ordering issues.
+# Note: gofmt in ale_linters is fine — linters only report errors, not reformat.
+echo "→ Go format-on-save: ALE fixers must not include gofmt/goimports when LSP formats"
+lsp_has_format=$(grep -c 'LspDocumentFormatSync\|LspCodeActionSync' "$VIMRC" 2>/dev/null || true)
+if [ "$lsp_has_format" -gt 0 ]; then
+  # Use awk to check specifically inside the ale_fixers dict (not ale_linters)
+  if awk '
+    /let g:ale_fixers/ { in_fixers = 1; next }
+    in_fixers && /^let / { in_fixers = 0 }
+    in_fixers && /'"'"'go'"'"'/ && (/gofmt/ || /goimports/) {
+      printf "  %s:%d: go in ale_fixers with gofmt/goimports\n", FILENAME, NR
+      found = 1
+    }
+    END { exit (found ? 1 : 0) }
+  ' "$VIMRC"; then
+    pass
+  else
+    fail "remove gofmt/goimports from go in g:ale_fixers — gopls handles format via LspDocumentFormatSync"
+  fi
+else
+  echo "  OK (no LSP format on save configured)"
+fi
+
+echo ""
+if [ "$fail" -ne 0 ]; then
+  echo "vimrc antipattern checks FAILED"
+  exit 1
+fi
+echo "All antipattern checks passed."

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -197,3 +197,65 @@ TOML
           done < <(find ./dot_zsh -type f -print0 2>/dev/null)
 
           exit "$fail"
+
+  # ── Vimscript syntax + antipattern checks ──────────────────────────────────
+  vimrc:
+    name: vimrc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install vim
+        run: sudo apt-get install -y --no-install-recommends vim
+
+      - name: Syntax check (source with vim-plug stubs)
+        run: |
+          # Generate a wrapper that stubs vim-plug before sourcing the real vimrc.
+          # vim-plug's plug#begin / plug#end / Plug commands are not installed in CI.
+          # plug#end also normally enables filetype/syntax, so we replicate that.
+          cat > /tmp/vimrc_check.vim << EOF
+          function! plug#begin(...) abort
+          endfunction
+          function! plug#end() abort
+            filetype plugin indent on
+            syntax on
+          endfunction
+          command! -nargs=+ Plug :
+          try
+            source $GITHUB_WORKSPACE/dot_vim/vimrc
+          catch
+            echoerr v:exception
+            cquit
+          endtry
+          qall!
+          EOF
+
+          # -e: ex mode  -s: silent  --not-a-term: suppress terminal warnings
+          # -u NONE: no init file  --noplugin: skip system plugins
+          output=$(vim -e -s --not-a-term -u NONE --noplugin \
+            -S /tmp/vimrc_check.vim 2>&1 || true)
+
+          errors=$(printf '%s\n' "$output" \
+            | grep -v '^$' \
+            | grep -v '^Vim: Warning:' \
+            || true)
+
+          if [ -n "$errors" ]; then
+            echo "vim reported errors when sourcing vimrc:"
+            echo "$errors"
+            exit 1
+          fi
+          echo "OK: vimrc loaded without errors"
+
+      - name: Antipattern checks
+        run: bash .github/scripts/check-vimrc-patterns.sh dot_vim/vimrc
+
+  # ── UltiSnips snippet structure ────────────────────────────────────────────
+  snippets:
+    name: UltiSnips snippets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate snippet structure
+        run: python3 .github/scripts/check-snippets.py dot_vim/UltiSnips

--- a/Brewfile
+++ b/Brewfile
@@ -37,6 +37,9 @@ brew "typescript-language-server"  # TypeScript/JavaScript language server
 brew "vscode-langservers-extracted"  # JSON, HTML, CSS, ESLint language servers
 brew "bash-language-server"  # Bash/Shell script language server
 
+# Debugging
+brew "delve"  # Go debugger (dlv) - used for step-through debugging in interview sessions
+
 # Linters & Formatters
 brew "golangci-lint"  # Go meta-linter
 brew "ruff"  # Fast Python linter & formatter

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,77 @@ The main MCP configuration is at `Library/private_Application Support/private_Cl
 - Work-specific MCPs are conditionally included based on username
 - Custom MCPs installed via personal Homebrew tap: `conallob/tap`
 
+## dot_vim — Vim Configuration
+
+The Vim configuration lives in `dot_vim/` (deployed to `~/.vim/`) and uses vim-plug for plugin management.
+
+### After any config change, apply and install
+
+```bash
+chezmoi apply ~/.vim/vimrc
+vim +PlugInstall +qall      # install/update plugins
+```
+
+### Sanity-check: Go LSP (3-step manual test)
+
+Create a throwaway file and verify the three core features:
+
+```bash
+mkdir -p /tmp/gotest && cd /tmp/gotest && go mod init gotest
+vim main.go
+```
+
+**Step 1 – Completions + struct field completion**
+```go
+package main
+
+import "fmt"
+
+type Person struct {
+    Name string `json:"name"`
+    Age  int    `json:"age"`
+}
+
+func main() {
+    p := Person{}
+    fmt.Println(p.  // type p. then wait — gopls should show Name, Age
+}
+```
+In insert mode, type `p.` and wait ~300 ms for the completion menu. You should see `Name` and `Age` from gopls.
+
+**Step 2 – Signature help on `(`**
+On the `fmt.Println(` line, enter insert mode and type `fmt.Println(`. The status line or a popup should display the function signature. If not, run `:LspStatus` and check gopls is running.
+
+**Step 3 – goimports on save**
+Delete the `import "fmt"` line, save (`:w`). On save, gopls runs `source.organizeImports` then `LspDocumentFormatSync` — the import should be re-added automatically. Confirm with `:!cat main.go`.
+
+### Key LSP bindings (Go and all LSP-enabled files)
+
+| Key | Action |
+|-----|--------|
+| `gd` | Go to definition |
+| `gr` | Find references |
+| `gi` | Go to implementation |
+| `K`  | Hover docs |
+| `<leader>rn` | Rename symbol |
+| `<leader>ca` | Code action |
+| `[g` / `]g` | Prev/next diagnostic |
+
+### Snippet engine (UltiSnips)
+
+Snippets live in `dot_vim/UltiSnips/`. Trigger with `<C-e>`, jump with `<C-j>`/`<C-k>`.
+Common Go snippets: `iferr`, `handler`, `marshal`, `unmarshal`, `readfile`, `test`.
+
+### REST client (vim-rest-console)
+
+Create a `requests.rest` file, write an HTTP request, press `<localleader>rr` (`\rr` by default) to execute:
+
+```
+GET http://localhost:8080/health HTTP/1.1
+```
+
+Response appears in a split buffer, auto-formatted as JSON.
+
 ## Important Files
 
 - **Brewfile**: Package dependencies for macOS (Homebrew bundle)

--- a/dot_vim/UltiSnips/all.snippets
+++ b/dot_vim/UltiSnips/all.snippets
@@ -1,0 +1,13 @@
+# Universal snippets (all file types)
+
+snippet todo "TODO comment" i
+TODO(${1:who}): ${2}
+endsnippet
+
+snippet fixme "FIXME comment" i
+FIXME(${1:who}): ${2}
+endsnippet
+
+snippet date "current date" i
+`date +%Y-%m-%d`
+endsnippet

--- a/dot_vim/UltiSnips/go.snippets
+++ b/dot_vim/UltiSnips/go.snippets
@@ -1,0 +1,184 @@
+# Go snippets for interview prep
+# Expand with <C-e>, jump with <C-j>/<C-k>
+
+# ── Error handling ───────────────────────────────────────────────────────────
+
+snippet iferr "if err != nil { return }" b
+if err != nil {
+	return ${1:nil}, err
+}
+endsnippet
+
+snippet iferrl "if err != nil { log + return }" b
+if err != nil {
+	log.Printf("${1:operation}: %v", err)
+	return ${2:nil}, err
+}
+endsnippet
+
+snippet errfmt "fmt.Errorf with %w wrap" i
+fmt.Errorf("${1:context}: %w", err)
+endsnippet
+
+# ── Functions ────────────────────────────────────────────────────────────────
+
+snippet fn "plain function" b
+func ${1:name}(${2}) ${3:error} {
+	${4}
+}
+endsnippet
+
+snippet main "main function" b
+func main() {
+	${1}
+}
+endsnippet
+
+# ── HTTP handlers ────────────────────────────────────────────────────────────
+
+snippet handler "http.HandlerFunc signature" b
+func ${1:handlerName}(w http.ResponseWriter, r *http.Request) {
+	${2}
+}
+endsnippet
+
+snippet handlerf "http handler returning JSON" b
+func ${1:handlerName}(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	resp := ${2:struct{}{}}
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+endsnippet
+
+snippet mux "http.NewServeMux + ListenAndServe" b
+mux := http.NewServeMux()
+mux.HandleFunc("${1:GET /path}", ${2:handler})
+if err := http.ListenAndServe(":${3:8080}", mux); err != nil {
+	log.Fatal(err)
+}
+endsnippet
+
+# ── JSON marshalling ─────────────────────────────────────────────────────────
+
+snippet jsonstruct "JSON-tagged struct" b
+type ${1:Name} struct {
+	${2:Field} ${3:string} `json:"${4:field}"`
+}
+endsnippet
+
+snippet marshal "json.Marshal with error check" b
+${1:data}, err := json.Marshal(${2:v})
+if err != nil {
+	return ${3:nil}, fmt.Errorf("marshal: %w", err)
+}
+endsnippet
+
+snippet unmarshal "json.Unmarshal with error check" b
+var ${1:result} ${2:Type}
+if err := json.Unmarshal(${3:data}, &${1:result}); err != nil {
+	return ${4:nil}, fmt.Errorf("unmarshal: %w", err)
+}
+endsnippet
+
+snippet encode "json.NewEncoder(w).Encode" b
+if err := json.NewEncoder(${1:w}).Encode(${2:v}); err != nil {
+	return ${3:nil}, fmt.Errorf("encode: %w", err)
+}
+endsnippet
+
+snippet decode "json.NewDecoder(r.Body).Decode" b
+var ${1:input} ${2:Type}
+if err := json.NewDecoder(${3:r.Body}).Decode(&${1:input}); err != nil {
+	http.Error(${4:w}, err.Error(), http.StatusBadRequest)
+	return
+}
+endsnippet
+
+# ── File I/O ─────────────────────────────────────────────────────────────────
+
+snippet readfile "os.ReadFile" b
+${1:data}, err := os.ReadFile("${2:filename}")
+if err != nil {
+	return ${3:nil}, fmt.Errorf("read file: %w", err)
+}
+endsnippet
+
+snippet writefile "os.WriteFile" b
+if err := os.WriteFile("${1:filename}", ${2:data}, 0o644); err != nil {
+	return ${3:nil}, fmt.Errorf("write file: %w", err)
+}
+endsnippet
+
+snippet openfile "os.Open with defer Close" b
+f, err := os.Open("${1:filename}")
+if err != nil {
+	return ${2:nil}, fmt.Errorf("open: %w", err)
+}
+defer f.Close()
+${3}
+endsnippet
+
+snippet createfile "os.Create with defer Close" b
+f, err := os.Create("${1:filename}")
+if err != nil {
+	return ${2:nil}, fmt.Errorf("create: %w", err)
+}
+defer f.Close()
+${3}
+endsnippet
+
+# ── Context ───────────────────────────────────────────────────────────────────
+
+snippet ctx "context.Background()" b
+ctx := context.Background()
+endsnippet
+
+snippet ctxto "context.WithTimeout + defer cancel" b
+ctx, cancel := context.WithTimeout(${1:context.Background()}, ${2:30}*time.Second)
+defer cancel()
+endsnippet
+
+# ── Concurrency ───────────────────────────────────────────────────────────────
+
+snippet goroutine "anonymous goroutine" b
+go func() {
+	${1}
+}()
+endsnippet
+
+snippet chan "make buffered channel" b
+${1:ch} := make(chan ${2:int}, ${3:1})
+endsnippet
+
+snippet select "select statement" b
+select {
+case ${1:v} := <-${2:ch}:
+	${3}
+case <-ctx.Done():
+	return ctx.Err()
+}
+endsnippet
+
+# ── Testing ───────────────────────────────────────────────────────────────────
+
+snippet test "table-driven test function" b
+func Test${1:Name}(t *testing.T) {
+	tests := []struct {
+		name string
+		${2:input} ${3:string}
+		want  ${4:string}
+	}{
+		{name: "${5:case}", ${2:input}: ${6}, want: ${7}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ${8:func}(tt.${2:input})
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+endsnippet

--- a/dot_vim/vimrc
+++ b/dot_vim/vimrc
@@ -21,7 +21,12 @@ set completeopt=menuone,noinsert,noselect,preview
 set shortmess+=c              " Don't show completion messages
 set cmdheight=2               " More space for messages
 set mouse=a                   " Enable mouse support
-set clipboard=unnamedplus     " Use system clipboard
+" Use system clipboard when available (unnamedplus=X11/Wayland, unnamed=macOS)
+if has('unnamedplus')
+  set clipboard=unnamedplus
+elseif has('clipboard')
+  set clipboard=unnamed
+endif
 set laststatus=2              " Always show status line
 set showcmd                   " Show command in bottom bar
 set wildmenu                  " Visual autocomplete for command menu
@@ -69,6 +74,12 @@ Plug 'prabirshrestha/asyncomplete-lsp.vim'          " LSP source for asyncomplet
 Plug 'dense-analysis/ale'                           " Linting and fixing
 Plug 'honza/vim-snippets'                           " Snippet collection
 
+" --- Snippet Engine ---
+Plug 'SirVer/ultisnips'                             " Snippet engine (requires +python3)
+Plug 'prabirshrestha/asyncomplete-ultisnips.vim'    " UltiSnips source for asyncomplete
+Plug 'prabirshrestha/asyncomplete-buffer.vim'       " Buffer word completion source
+Plug 'prabirshrestha/asyncomplete-file.vim'         " File path completion source
+
 " --- AI Assistance ---
 Plug 'madox2/vim-ai'                                " Claude/OpenAI integration
 
@@ -110,6 +121,9 @@ Plug 'tpope/vim-surround'                           " Surround text objects
 Plug 'jiangmiao/auto-pairs'                         " Auto-close brackets
 Plug 'yggdroot/indentline'                          " Show indent guides
 Plug 'editorconfig/editorconfig-vim'                " EditorConfig support
+
+" --- REST Client ---
+Plug 'diepm/vim-rest-console'                       " HTTP request testing and debugging
 
 " --- Clipboard ---
 Plug 'ojroques/vim-oscyank', {'branch': 'main'}     " OSC 52 clipboard (works over SSH, without X11)
@@ -175,7 +189,11 @@ function! s:on_lsp_buffer_enabled() abort
     nmap <buffer> K <plug>(lsp-hover)
     nmap <buffer> <leader>ca <plug>(lsp-code-action)
 
-    " Format on save (can be disabled per filetype if needed)
+    " For Go: run gopls source.organizeImports first (goimports behaviour),
+    " then format. Other filetypes just format.
+    if &filetype ==# 'go'
+        autocmd BufWritePre <buffer> LspCodeActionSync source.organizeImports
+    endif
     autocmd BufWritePre <buffer> LspDocumentFormatSync
 endfunction
 
@@ -192,6 +210,18 @@ let g:lsp_diagnostics_signs_enabled = 1
 let g:lsp_document_highlight_enabled = 1
 let g:lsp_fold_enabled = 0
 let g:lsp_semantic_enabled = 1
+let g:lsp_signature_help_enabled = 1   " Show signature help when '(' is typed
+let g:lsp_signature_help_delay = 50
+
+" gopls initialization options: enable completion placeholders and staticcheck
+let g:lsp_settings = {
+\  'gopls': {
+\    'initialization_options': {
+\      'ui.completion.usePlaceholders': v:true,
+\      'ui.diagnostic.staticcheck': v:true,
+\    }
+\  }
+\}
 
 " Diagnostic signs
 let g:lsp_diagnostics_signs_error = {'text': '✗'}
@@ -216,12 +246,15 @@ let g:ale_linters = {
 \   'sh': ['shellcheck'],
 \   'yaml': ['yamllint'],
 \   'dockerfile': ['hadolint'],
+\   'json': ['jq'],
+\   'rest': [''],
 \}
 
 " Fixers by filetype
+" Note: Go is intentionally absent — gopls (LSP) handles formatting and
+" import management via source.organizeImports + LspDocumentFormatSync on save.
 let g:ale_fixers = {
 \   '*': ['remove_trailing_lines', 'trim_whitespace'],
-\   'go': ['gofmt', 'goimports'],
 \   'python': ['black', 'isort'],
 \   'javascript': ['prettier'],
 \   'typescript': ['prettier'],
@@ -240,26 +273,67 @@ inoremap <expr> <Tab>   pumvisible() ? "\<C-n>" : "\<Tab>"
 inoremap <expr> <S-Tab> pumvisible() ? "\<C-p>" : "\<S-Tab>"
 inoremap <expr> <CR>    pumvisible() ? asyncomplete#close_popup() : "\<CR>"
 
+" Register completion sources on asyncomplete setup
+if exists('*asyncomplete#sources#ultisnips#completor')
+  au User asyncomplete_setup call asyncomplete#register_source(asyncomplete#sources#ultisnips#get_source_options({
+  \ 'name': 'ultisnips',
+  \ 'whitelist': ['*'],
+  \ 'completor': function('asyncomplete#sources#ultisnips#completor'),
+  \ }))
+endif
+
+if exists('*asyncomplete#sources#buffer#completor')
+  au User asyncomplete_setup call asyncomplete#register_source(asyncomplete#sources#buffer#get_source_options({
+  \ 'name': 'buffer',
+  \ 'whitelist': ['*'],
+  \ 'blacklist': ['go', 'python'],
+  \ 'completor': function('asyncomplete#sources#buffer#completor'),
+  \ }))
+endif
+
+if exists('*asyncomplete#sources#file#completor')
+  au User asyncomplete_setup call asyncomplete#register_source(asyncomplete#sources#file#get_source_options({
+  \ 'name': 'file',
+  \ 'whitelist': ['*'],
+  \ 'priority': 10,
+  \ 'completor': function('asyncomplete#sources#file#completor'),
+  \ }))
+endif
+
 " ============================================================================
 " AI Integration (vim-ai for Claude)
 " ============================================================================
-" vim-ai uses OPENAI_API_KEY by default, but can be configured for Claude
-" Set environment variables in your shell or use 1Password integration
-let g:vim_ai_chat = {
-\  "options": {
-\    "model": "claude-3-5-sonnet-20241022",
-\    "endpoint_url": "https://api.anthropic.com/v1/messages",
-\    "max_tokens": 4096,
-\    "temperature": 0.7,
-\  },
-\}
+" Requires +python3 and ANTHROPIC_API_KEY environment variable.
+" Set ANTHROPIC_API_KEY in shell profile or via 1Password integration.
+if has('python3')
+  let s:ai_opts = {
+  \  "model": "claude-3-5-sonnet-20241022",
+  \  "endpoint_url": "https://api.anthropic.com/v1/messages",
+  \  "max_tokens": 4096,
+  \  "temperature": 0.7,
+  \  "request_timeout": 20,
+  \  "enable_auth": 1,
+  \  "token_file_path": "",
+  \}
 
-" AI keybindings
-nnoremap <leader>ai :AI
-vnoremap <leader>ai :AI
-nnoremap <leader>ae :AIEdit
-vnoremap <leader>ae :AIEdit
-nnoremap <leader>ac :AIChat<CR>
+  let g:vim_ai_complete = {"options": s:ai_opts}
+  let g:vim_ai_edit     = {"options": s:ai_opts}
+  let g:vim_ai_chat = {
+  \  "options": s:ai_opts,
+  \  "ui": {
+  \    "open_chat_command": "preset_below",
+  \    "scratch_buffer_keep_open": 0,
+  \    "populate_options": 0,
+  \    "code_syntax_enabled": 1,
+  \  },
+  \}
+
+  nnoremap <leader>ai :AI
+  vnoremap <leader>ai :AI
+  nnoremap <leader>ae :AIEdit
+  vnoremap <leader>ae :AIEdit
+  nnoremap <leader>ac :AIChat<CR>
+endif
 
 " ============================================================================
 " FZF Configuration
@@ -353,7 +427,8 @@ augroup END
 " Go Configuration (vim-go)
 " ============================================================================
 let g:go_fmt_command = "goimports"
-let g:go_auto_type_info = 1
+let g:go_fmt_autosave = 0        " Disable vim-go auto-format; LSP handles it via gopls
+let g:go_auto_type_info = 0      " Disable vim-go type info; LSP hover (K) replaces it
 let g:go_highlight_types = 1
 let g:go_highlight_fields = 1
 let g:go_highlight_functions = 1
@@ -376,6 +451,42 @@ autocmd FileType go nmap <leader>ga <Plug>(go-alternate-edit)
 autocmd FileType go nmap <leader>gd <Plug>(go-doc)
 autocmd FileType go nmap <leader>gi :GoImpl<CR>
 autocmd FileType go nmap <leader>gf :GoFillStruct<CR>
+
+" ============================================================================
+" UltiSnips Configuration (Snippet Engine)
+" ============================================================================
+if has('python3')
+  let g:UltiSnipsExpandTrigger = "<C-e>"         " Expand snippet (avoids Tab/CR conflict)
+  let g:UltiSnipsJumpForwardTrigger = "<C-j>"    " Jump to next tabstop in snippet
+  let g:UltiSnipsJumpBackwardTrigger = "<C-k>"   " Jump to previous tabstop in snippet
+  let g:UltiSnipsEditSplit = "vertical"
+  let g:UltiSnipsSnippetDirectories = ['UltiSnips', $HOME . '/.vim/UltiSnips']
+endif
+
+" ============================================================================
+" REST Client Configuration (vim-rest-console)
+" ============================================================================
+" Open a .rest or .http file and press <C-j> to execute the request under cursor.
+" Result is shown in a new split buffer.
+let g:vrc_auto_format_response_patterns = {
+\   'json': 'python3 -m json.tool',
+\}
+let g:vrc_show_command = 0
+let g:vrc_response_default_content_type = 'application/json'
+let g:vrc_output_buffer_name = '__VRC_OUTPUT__'
+let g:vrc_trigger = '<localleader>rr'
+
+autocmd BufRead,BufNewFile *.rest,*.http set filetype=rest
+
+" ============================================================================
+" JSON Configuration
+" ============================================================================
+autocmd FileType json setlocal ts=2 sts=2 sw=2 expandtab conceallevel=0
+
+" Format current JSON buffer in-place via jq
+command! FormatJSON %!jq '.'
+nnoremap <leader>jf :FormatJSON<CR>
+vnoremap <leader>jf :!jq '.'<CR>
 
 " ============================================================================
 " Python Configuration
@@ -588,10 +699,12 @@ autocmd BufReadPost *
 " Automatically equalize splits when vim is resized
 autocmd VimResized * wincmd =
 
-" Highlight yanked text
+" Highlight yanked text (neovim only; regular vim uses search highlight flash)
 augroup highlight_yank
     autocmd!
-    autocmd TextYankPost * silent! lua vim.highlight.on_yank {higroup="IncSearch", timeout=300}
+    if has('nvim')
+        autocmd TextYankPost * silent! lua vim.highlight.on_yank {higroup="IncSearch", timeout=300}
+    endif
 augroup END
 
 " ============================================================================
@@ -620,9 +733,11 @@ endif
 " ============================================================================
 " OSC 52 Clipboard (vim-oscyank)
 " ============================================================================
-" Automatically sync yanks to the terminal clipboard via OSC 52.
-" Works over SSH and without X11 (complements 'vim -X' alias).
-" Triggers whenever text is yanked to the + register (clipboard=unnamedplus).
-if exists('g:loaded_oscyank')
-  autocmd TextYankPost * if v:event.operator is 'y' && v:event.regname is '+' | execute 'OSCYankRegister +' | endif
-endif
+" Sync yanks to the terminal clipboard via OSC 52 (works over SSH, no X11 needed).
+" Uses exists(':OSCYankRegister') instead of g:loaded_oscyank because vim-plug
+" plugins are added to runtimepath by plug#end() but sourced after the vimrc,
+" so g:loaded_oscyank is never set at parse time.
+autocmd TextYankPost *
+  \ if v:event.operator is 'y' && v:event.regname is '+' && exists(':OSCYankRegister') == 2 |
+  \   execute 'OSCYankRegister +' |
+  \ endif


### PR DESCRIPTION
## Bug fixes (`dot_vim/vimrc`)

- **vim-ai startup warning** — only `g:vim_ai_chat` was set; `g:vim_ai_complete` and `g:vim_ai_edit` defaulted to OpenAI config and warned on missing `OPENAI_API_KEY`. Fixed by adding a `has('python3')` guard and configuring all three with the Anthropic endpoint.
- **Clipboard** — `set clipboard=unnamedplus` was unconditional; silently does nothing on vim builds without `+clipboard` or without X11/Wayland. Now conditional on `has('unnamedplus')` / `has('clipboard')`.
- **OSCYank** — `if exists('g:loaded_oscyank')` is always false at vimrc parse time: vim-plug adds plugins to `&runtimepath` via `plug#end()` but sources their `plugin/*.vim` files *after* the vimrc completes. Replaced with `exists(':OSCYankRegister') == 2`, which evaluates at event time.
- **Neovim-only Lua** — `lua vim.highlight.on_yank` is a neovim API; in regular vim it errors even with `silent!`. Guarded with `if has('nvim')`.

## Go LSP (`dot_vim/vimrc`)

Previously vim-go's auto-format, ALE's gofmt/goimports fixer, and `LspDocumentFormatSync` all fired on `:w`, causing triple-formatting. Resolved by making gopls the single source of truth:

- `BufWritePre` for Go now runs `LspCodeActionSync source.organizeImports` (goimports behaviour) then `LspDocumentFormatSync`
- `g:go_fmt_autosave = 0` — vim-go no longer touches the file on save
- `g:go_auto_type_info = 0` — LSP hover (`K`) replaces vim-go's type info
- Go removed from `g:ale_fixers` (ALE linters still run for diagnostics)
- `g:lsp_signature_help_enabled = 1` and `g:lsp_signature_help_delay = 50` — signature popup on `(`
- `g:lsp_settings` with gopls `usePlaceholders` and `staticcheck` options

## New features

**Snippets** (`dot_vim/UltiSnips/`)
- Added UltiSnips engine (`SirVer/ultisnips`) with asyncomplete integration
- Added asyncomplete sources for buffer words and file paths
- `dot_vim/UltiSnips/go.snippets`: `iferr`, `iferrl`, `fn`, `main`, `handler`, `handlerf`, `mux`, `jsonstruct`, `marshal`, `unmarshal`, `encode`, `decode`, `readfile`, `writefile`, `openfile`, `createfile`, `ctx`, `ctxto`, `goroutine`, `chan`, `select`, `test`
- `dot_vim/UltiSnips/all.snippets`: `todo`, `fixme`, `date`
- Trigger: `<C-e>` to expand, `<C-j>`/`<C-k>` to jump tabstops

**REST client**
- Added `diepm/vim-rest-console`; execute requests in `.rest`/`.http` files with `\rr`; responses auto-formatted as JSON

**JSON**
- `FormatJSON` command (`:FormatJSON` / `<leader>jf`) runs `jq '.'` in-place
- `jq` added to `g:ale_linters` for JSON files

**Brewfile**
- Added `delve` (Go debugger, `dlv`) for step-through debugging

## CI (`.github/`)

Two jobs added to `lint.yml` (rebased on top of the yaml/json/shell/templates jobs from #33):

- **`vimrc`** — sources `dot_vim/vimrc` in vim ex-mode with vim-plug stubbed out to catch vimscript parse errors; then runs `check-vimrc-patterns.sh` with five antipattern checks:
  1. Unconditional `set clipboard=` without `has()` guard
  2. `exists('g:loaded_*')` guards (always false at parse time)
  3. `lua vim.*` calls outside `has('nvim')` guard
  4. vim-ai partial config (all three `g:vim_ai_*` must be set together)
  5. gofmt/goimports in `g:ale_fixers` for go when LSP format-on-save is active (uses awk to check specifically inside the `ale_fixers` dict, not `ale_linters`)

- **`snippets`** — `check-snippets.py` validates `dot_vim/UltiSnips/*.snippets` for balanced `snippet`/`endsnippet` pairs, no nested blocks, no stray `endsnippet`

## CLAUDE.md

Added `dot_vim` section with: apply+install workflow, 3-step Go LSP sanity check (completions, signature help, goimports-on-save), LSP key binding reference, UltiSnips and REST client usage.