### PR TITLE
fix: preserve newline after shebang in modify_dot_claude.json.tmpl

### DIFF
--- a/modify_dot_claude.json.tmpl
+++ b/modify_dot_claude.json.tmpl
@@ -1,5 +1,5 @@
 #!/bin/bash
-{{- /* chezmoi modify script: merges base config and MCP servers into ~/.claude.json */ -}}
+# chezmoi modify script: merges base config and MCP servers into ~/.claude.json
 set -euo pipefail
 
 MCP_SERVERS=$(mktemp)


### PR DESCRIPTION
## Problem

`chezmoi update --apply` was failing with:

```
chezmoi: .claude.json: fork/exec /var/folders/.../T/1080654440..claude.json: no such file or directory
```

## Root cause

The Go template comment on line 2 used left-trim syntax (`{{-`):

```bash
#!/bin/bash
{{- /* chezmoi modify script: ... */ -}}
set -euo pipefail
```

`{{-` strips all preceding whitespace including newlines, so the rendered script started with:

```
#!/bin/bashset -euo pipefail
```

The kernel reads the entire first line as the interpreter path and tried to exec `/bin/bashset`, which doesn't exist — hence `ENOENT`.

## Fix

Replace the Go template comment with a plain bash `#` comment, which keeps the shebang on its own line and avoids the trim-marker footgun entirely.

---
_Generated by [Claude Code](https://claude.ai/code/session_014nmE8GrpaEs3inBDszQjmA)_