### PR TITLE
fix: preserve newline after shebang in modify_dot_claude.json.tmpl

### DIFF
--- a/modify_dot_claude.json.tmpl
+++ b/modify_dot_claude.json.tmpl
@@ -1,5 +1,5 @@
 #!/bin/bash
-{{- /* chezmoi modify script: merges base config and MCP servers into ~/.claude.json */ -}}
+# chezmoi modify script: merges base config and MCP servers into ~/.claude.json
 set -euo pipefail
 
 MCP_SERVERS=$(mktemp)


### PR DESCRIPTION
The Go template comment {{- /* ... */ -}} used left-trim ({{-), which stripped the newline after #!/bin/bash. The rendered script started with #!/bin/bashset making the kernel look for /bin/bashset as the interpreter, causing: fork/exec ...: no such file or directory

Replace with a plain bash comment to keep the shebang on its own line.

https://claude.ai/code/session_014nmE8GrpaEs3inBDszQjmA