### PR TITLE
Fix Python 3 detection for vim-plug plugins

### DIFF
--- a/dot_vim/vimrc
+++ b/dot_vim/vimrc
@@ -75,8 +75,10 @@ Plug 'dense-analysis/ale'                           " Linting and fixing
 Plug 'honza/vim-snippets'                           " Snippet collection
 
 " --- Snippet Engine ---
-Plug 'SirVer/ultisnips'                             " Snippet engine (requires +python3)
-Plug 'prabirshrestha/asyncomplete-ultisnips.vim'    " UltiSnips source for asyncomplete
+if has('python3')
+  Plug 'SirVer/ultisnips'                           " Snippet engine (requires +python3)
+  Plug 'prabirshrestha/asyncomplete-ultisnips.vim'  " UltiSnips source for asyncomplete
+endif
 Plug 'prabirshrestha/asyncomplete-buffer.vim'       " Buffer word completion source
 Plug 'prabirshrestha/asyncomplete-file.vim'         " File path completion source
 
@@ -90,7 +92,9 @@ Plug 'vim-test/vim-test'                            " Language-agnostic test run
 Plug 'mg979/vim-visual-multi', {'branch': 'master'} " Multiple cursors (Ctrl-N)
 
 " --- AI Assistance ---
-Plug 'madox2/vim-ai'                                " Claude/OpenAI integration
+if has('python3')
+  Plug 'madox2/vim-ai'                              " Claude/OpenAI integration
+endif
 
 " --- Git Integration ---
 Plug 'tpope/vim-fugitive'                           " Git wrapper
@@ -628,10 +632,10 @@ autocmd FileType markdown TableModeEnable
 autocmd BufRead,BufNewFile *.d2 setfiletype d2
 
 " ALE fixer: `d2 fmt -` reads from stdin, writes formatted diagram to stdout
-function! s:AleFixD2(buffer) abort
+function! AleFixD2(buffer) abort
   return {'command': 'd2 fmt -'}
 endfunction
-call ale#fix#registry#Add('d2fmt', function('s:AleFixD2'), ['d2'], 'Format D2 diagrams')
+call ale#fix#registry#Add('d2fmt', 'AleFixD2', ['d2'], 'Format D2 diagrams')
 
 autocmd FileType d2 setlocal ts=2 sts=2 sw=2 expandtab
 
@@ -641,18 +645,18 @@ autocmd FileType d2 setlocal ts=2 sts=2 sw=2 expandtab
 " Syntax via vim-polyglot (proto3 included). LSP via buf-ls registered above.
 " ALE: buf_lint for diagnostics, buf_fmt fixer for format-on-save.
 
-function! s:AleFixBufFmt(buffer) abort
+function! AleFixBufFmt(buffer) abort
   return {'command': 'buf format -'}
 endfunction
-call ale#fix#registry#Add('buf_fmt', function('s:AleFixBufFmt'), ['proto'], 'Format protobuf with buf')
+call ale#fix#registry#Add('buf_fmt', 'AleFixBufFmt', ['proto'], 'Format protobuf with buf')
 
 " keep-sorted: sorts regions delimited by "keep-sorted start/end" comments.
 " No-op on files without markers — safe to include in '*' fixers for all types.
 " Markers vary by language comment style; see UltiSnips snippets (trigger: ks).
-function! s:AleFixKeepSorted(buffer) abort
+function! AleFixKeepSorted(buffer) abort
   return {'command': 'keep-sorted -'}
 endfunction
-call ale#fix#registry#Add('keep_sorted', function('s:AleFixKeepSorted'), [], 'Sort keep-sorted regions')
+call ale#fix#registry#Add('keep_sorted', 'AleFixKeepSorted', [], 'Sort keep-sorted regions')
 
 " :KeepSorted — run keep-sorted on the whole buffer immediately (no save needed).
 " Useful for one-off sorting or in files where ale_fix_on_save is disabled.

--- a/dot_vim/vimrc
+++ b/dot_vim/vimrc
@@ -60,6 +60,18 @@ nnoremap <leader>/ :nohlsearch<CR>
 " ============================================================================
 " Plugins (via vim-plug)
 " ============================================================================
+
+" Probe for working python3: has('python3') can return 1 even when the py3
+" command fails at runtime (e.g. macOS system vim with broken dynamic link).
+let s:has_python3 = 0
+if has('python3')
+  try
+    python3 pass
+    let s:has_python3 = 1
+  catch
+  endtry
+endif
+
 call plug#begin('~/.vim/plugged')
 
 " --- Core Plugins ---
@@ -75,7 +87,7 @@ Plug 'dense-analysis/ale'                           " Linting and fixing
 Plug 'honza/vim-snippets'                           " Snippet collection
 
 " --- Snippet Engine ---
-if has('python3')
+if s:has_python3
   Plug 'SirVer/ultisnips'                           " Snippet engine (requires +python3)
   Plug 'prabirshrestha/asyncomplete-ultisnips.vim'  " UltiSnips source for asyncomplete
 endif
@@ -92,7 +104,7 @@ Plug 'vim-test/vim-test'                            " Language-agnostic test run
 Plug 'mg979/vim-visual-multi', {'branch': 'master'} " Multiple cursors (Ctrl-N)
 
 " --- AI Assistance ---
-if has('python3')
+if s:has_python3
   Plug 'madox2/vim-ai'                              " Claude/OpenAI integration
 endif
 
@@ -375,7 +387,7 @@ endif
 " ============================================================================
 " Requires +python3 and ANTHROPIC_API_KEY environment variable.
 " Set ANTHROPIC_API_KEY in shell profile or via 1Password integration.
-if has('python3')
+if s:has_python3
   let s:ai_opts = {
   \  "model": "claude-3-5-sonnet-20241022",
   \  "endpoint_url": "https://api.anthropic.com/v1/messages",
@@ -567,7 +579,7 @@ autocmd FileType go nmap <leader>gf :GoFillStruct<CR>
 " ============================================================================
 " UltiSnips Configuration (Snippet Engine)
 " ============================================================================
-if has('python3')
+if s:has_python3
   let g:UltiSnipsExpandTrigger = "<C-e>"         " Expand snippet (avoids Tab/CR conflict)
   let g:UltiSnipsJumpForwardTrigger = "<C-j>"    " Jump to next tabstop in snippet
   let g:UltiSnipsJumpBackwardTrigger = "<C-k>"   " Jump to previous tabstop in snippet


### PR DESCRIPTION
## Summary

Adds robust Python 3 detection to handle cases where `has('python3')` returns true but the `python3` command fails at runtime (e.g., macOS system vim with broken dynamic linking). Conditionally loads Python-dependent plugins and refactors ALE fixer functions to use public naming.

## Key Changes

- **Python 3 detection**: Added `s:has_python3` variable that probes for working Python 3 by attempting to execute `python3 pass` in a try-catch block, rather than relying solely on `has('python3')`
- **Conditional plugin loading**: Wrapped Python-dependent plugins (UltiSnips, asyncomplete-ultisnips, vim-ai) in `if s:has_python3` guards to prevent load failures
- **Configuration guards**: Updated Python 3 checks in AI assistance and UltiSnips configuration sections to use `s:has_python3`
- **ALE fixer refactoring**: Changed ALE fixer functions from script-scoped (`s:AleFixD2`, `s:AleFixBufFmt`, `s:AleFixKeepSorted`) to public functions and updated registry calls to use function names as strings instead of `function()` references

## Implementation Details

The Python 3 probe is placed early in the plugins section (before `plug#begin()`) so the result is available for all subsequent conditional plugin declarations. This ensures plugins are only registered if Python 3 is actually usable, preventing runtime errors during plugin initialization.

The ALE fixer changes align with vim-plug best practices for function references and improve debuggability by using public function names.

https://claude.ai/code/session_01VH3NRxbiY6oD5dDAi7NiTM