### PR TITLE
fix: set Hack Nerd Font in Ghostty and enable termguicolors for vim

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -4,6 +4,8 @@ cursor-invert-fg-bg = true
 window-height = 58
 window-width = 80
 keybind = shift+enter=text:\n
+font-family = Hack Nerd Font
+font-size = 13
 
 # Desktop notifications
 desktop-notifications = true

--- a/dot_vim/vimrc
+++ b/dot_vim/vimrc
@@ -37,10 +37,9 @@ set splitright                " Vertical splits to the right
 set splitbelow                " Horizontal splits below
 
 " Enable true colors if terminal supports it
-" Note: Disable this if you want terminal transparency
-"if !has('gui_running') && &term =~ '^\%(screen\|tmux\|xterm-256color\|xterm-ghostty\)'
-"  set termguicolors
-"endif
+if !has('gui_running') && &term =~ '^\%(screen\|tmux\|xterm-256color\|xterm-ghostty\)'
+  set termguicolors
+endif
 
 " Fix delete key, per http://panic.com/prompt/support.html
 :fixdel


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Set `font-family = Hack Nerd Font` in Ghostty config so vim-airline powerline separators and vim-devicons glyphs render correctly (Hack Nerd Font is already in the Brewfile)
- Add `font-size = 13` as a sensible default since no font size was previously configured
- Uncomment `termguicolors` for `xterm-ghostty` in vimrc so vim uses 24-bit true color instead of 256-color mode, fixing airline colour accuracy

## Test plan

- [ ] Restart Ghostty after applying (`chezmoi apply`)
- [ ] Open vim — airline status bar should show proper powerline arrows, branch icon, and line/column glyphs
- [ ] Colours in the status bar should match the gruvbox theme accurately

https://claude.ai/code/session_01VH3NRxbiY6oD5dDAi7NiTM
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VH3NRxbiY6oD5dDAi7NiTM)_