### PR TITLE
fix: use Hack Nerd Font Mono variant in Ghostty

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -4,6 +4,8 @@ cursor-invert-fg-bg = true
 window-height = 58
 window-width = 80
 keybind = shift+enter=text:\n
+font-family = Hack Nerd Font Mono
+font-size = 13
 
 # Desktop notifications
 desktop-notifications = true


### PR DESCRIPTION
Followup to #41.

The previous PR set `font-family = Hack Nerd Font` (proportional variant) but terminals require the **Mono** variant for correct glyph width alignment. Powerline separators and vim-devicons icons were still rendering as broken glyphs because Ghostty was treating the proportional variant's Nerd Font codepoints as double-width characters, misaligning the status bar.

## Test plan

- [ ] `chezmoi apply` and restart Ghostty
- [ ] Open vim — airline powerline arrows and branch/filetype glyphs should render cleanly

https://claude.ai/code/session_01VH3NRxbiY6oD5dDAi7NiTM

---
_Generated by [Claude Code](https://claude.ai/code/session_01VH3NRxbiY6oD5dDAi7NiTM)_