### PR TITLE
fix: correct onepasswordDetailsFields args in env.vim-ai.tmpl

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,21 @@ Secrets are stored in 1Password and templated at apply-time:
 - **Documents**: `onepasswordDocument` for full credential documents
 - Never commit raw secrets; always use 1Password template functions
 
+#### onepasswordDetailsFields usage
+
+```
+{{ (onepasswordDetailsFields "ITEM-UUID").FIELD.value }}
+```
+
+The function signature is `(item-uuid [vault-uuid [account-uuid]])`. The item UUID
+alone is sufficient — vault and account qualifiers are optional and can cause
+"no 1Password account found" errors if the wrong UUID is placed in the wrong
+position. Find the item UUID from the 1Password URL parameter `i=`.
+
+The field name matches the label shown by `op item get ITEM-UUID` (e.g.
+`credential`, `password`, `username`). Use `op item get ITEM-UUID --reveal`
+to confirm field names without exposing values in this file.
+
 ### Claude Desktop MCP Configuration
 
 The main MCP configuration is at `Library/private_Application Support/private_Claude/claude_desktop_config.json.tmpl`:

--- a/shell.d/env.vim-ai.tmpl
+++ b/shell.d/env.vim-ai.tmpl
@@ -1,18 +1,1 @@
-#!/bin/sh
-# vim-ai environment configuration
-# This file configures the Anthropic API key for Claude integration in Vim
-
-# Anthropic API Key for vim-ai plugin
-# This enables Claude AI assistance in Vim via the vim-ai plugin
-# Store your API key in 1Password under "Anthropic API" with field "api_key"
-# Or uncomment and set directly (not recommended for security):
-# export ANTHROPIC_API_KEY="sk-ant-..."
-
-{{- if eq .chezmoi.os "darwin" }}
-# macOS: Use 1Password CLI to fetch the API key
-if command -v op >/dev/null 2>&1; then
-  # Fetch API key from 1Password
-  # Adjust the vault and item name based on where you store your Anthropic API key
-  export ANTHROPIC_API_KEY="$(op read 'op://Private/Anthropic API/api_key' 2>/dev/null)"
-fi
-{{- end }}
+export ANTHROPIC_API_KEY="{{ (onepasswordDetailsFields "l26vtdxoguuassebp3iohrbdma").credential.value }}"


### PR DESCRIPTION
Fixes `chezmoi apply` error introduced in #43.

`onepasswordDetailsFields` takes `(item, vault, account)` — the vault UUID (`dyz4dyfpyrte2nesqaerlhqlkq`) was mistakenly passed as the third argument (account), causing chezmoi to fail with `no 1Password account found matching dyz4dyfpyrte2nesqaerlhqlkq`.

Since the item UUID is globally unique within 1Password, the vault and account qualifiers aren't needed. Simplified to `onepasswordDetailsFields "l26vtdxoguuassebp3iohrbdma"` with no extra args.

## Test plan

- [ ] `chezmoi apply` completes without error
- [ ] Deployed file contains a populated `ANTHROPIC_API_KEY=sk-ant-...` line
- [ ] `echo $ANTHROPIC_API_KEY` is set in a new shell

https://claude.ai/code/session_01VH3NRxbiY6oD5dDAi7NiTM

---
_Generated by [Claude Code](https://claude.ai/code/session_01VH3NRxbiY6oD5dDAi7NiTM)_