### PR TITLE
Configure airline statusline symbols for better visual appearance

### DIFF
--- a/dot_vim/vimrc
+++ b/dot_vim/vimrc
@@ -519,6 +519,19 @@ nmap <leader>hp <Plug>(GitGutterPreviewHunk)
 " ============================================================================
 let g:airline_powerline_fonts = 1
 let g:airline_theme = 'gruvbox'
+
+if !exists('g:airline_symbols')
+  let g:airline_symbols = {}
+endif
+let g:airline_left_sep           = ""
+let g:airline_left_alt_sep       = ""
+let g:airline_right_sep          = ""
+let g:airline_right_alt_sep      = ""
+let g:airline_symbols.branch     = ""
+let g:airline_symbols.readonly   = ""
+let g:airline_symbols.linenr     = ""
+let g:airline_symbols.maxlinenr  = "☰"
+let g:airline_symbols.dirty      = "⚡"
 let g:airline#extensions#tabline#enabled = 1
 let g:airline#extensions#tabline#formatter = 'unique_tail'
 let g:airline#extensions#ale#enabled = 1


### PR DESCRIPTION
Add explicit airline statusline symbol configuration to improve visual presentation in Vim.

## Summary
Configured vim-airline with custom Unicode symbols for statusline separators and indicators, replacing default symbols with more visually appealing alternatives.

## Changes
- Initialize `g:airline_symbols` dictionary if it doesn't exist
- Set left and right separator symbols using Unicode box-drawing characters
- Configure branch, readonly, line number, and dirty status indicators with custom Unicode symbols
- Maintains existing airline theme (gruvbox) and tabline configuration

## Implementation Details
The symbols are defined using Unicode characters:
- Separators use box-drawing characters for clean visual separation
- Branch indicator uses a git-style symbol
- Dirty status uses a lightning bolt (⚡) to indicate unsaved changes
- Line number display uses a pilcrow-style symbol (☰)

This enhances the visual feedback in the statusline without changing any functional behavior.

https://claude.ai/code/session_01GCpNarRYfG2md4CG59XAhb