### PR TITLE
Switch ghostty-transparency to toggle background-blur instead of opacity

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -1,5 +1,6 @@
 background = #0d0d0d
 background-opacity = 0.3
+background-blur = false
 cursor-invert-fg-bg = true
 window-height = 58
 window-width = 80

--- a/shell.d/alias.Darwin
+++ b/shell.d/alias.Darwin
@@ -19,7 +19,5 @@ ghostty-transparency() {
   fi
 
   sed -i '' "s/^background-opacity = .*/background-opacity = ${new_opacity}/" "$config"
-  echo "Ghostty: opacity set to ${new_opacity}"
-
-  ghostty +reload-config 2>/dev/null && echo "Config reloaded." || echo "Reload manually with ctrl+shift+,"
+  echo "Ghostty: opacity set to ${new_opacity} — restart Ghostty to apply."
 }

--- a/shell.d/alias.Darwin
+++ b/shell.d/alias.Darwin
@@ -22,5 +22,5 @@ ghostty-transparency() {
   sed -i '' "s/^background-blur = .*/background-blur = ${new_blur}/" "$config"
   echo "Ghostty: background-blur set to ${new_blur}"
 
-  ghostty +reload-config 2>/dev/null && echo "Config reloaded." || echo "Reload manually with ctrl+shift+,"
+  ghostty +reload-config 2>/dev/null && echo "Config reloaded. ✅" || echo "⚠️ Reload manually with ctrl+shift+, "
 }

--- a/shell.d/alias.Darwin
+++ b/shell.d/alias.Darwin
@@ -2,22 +2,25 @@
 
 alias eject="diskutil eject"
 
-# Toggle Ghostty background opacity between transparent (0.3) and presentation (0.95),
-# or set an explicit value. Calling without args after a custom value resets to 0.3.
+# Toggle Ghostty background blur for presentation mode (blur hot-reloads; opacity does not).
+# No arg: toggles false <-> true. With arg: sets that blur value (e.g. macos-glass-regular, 20).
+# Calling without args after a custom value resets to false.
 # shellcheck disable=SC3033,SC3043  # hyphenated name and local are fine in bash/zsh
 ghostty-transparency() {
   local config="$HOME/.config/ghostty/config"
-  local current_opacity new_opacity
-  current_opacity=$(awk -F' *= *' '/^background-opacity/{print $2}' "$config")
+  local current_blur new_blur
+  current_blur=$(awk -F' *= *' '/^background-blur/{print $2}' "$config")
 
   if [ -n "$1" ]; then
-    new_opacity="$1"
-  elif [ "$current_opacity" = "0.3" ]; then
-    new_opacity="0.95"
+    new_blur="$1"
+  elif [ "$current_blur" = "false" ]; then
+    new_blur="true"
   else
-    new_opacity="0.3"
+    new_blur="false"
   fi
 
-  sed -i '' "s/^background-opacity = .*/background-opacity = ${new_opacity}/" "$config"
-  echo "Ghostty: opacity set to ${new_opacity} — restart Ghostty to apply."
+  sed -i '' "s/^background-blur = .*/background-blur = ${new_blur}/" "$config"
+  echo "Ghostty: background-blur set to ${new_blur}"
+
+  ghostty +reload-config 2>/dev/null && echo "Config reloaded." || echo "Reload manually with ctrl+shift+,"
 }


### PR DESCRIPTION
Ghostty's `background-opacity` requires a full restart on macOS, making it unsuitable for a live toggle. Switch to toggling `background-blur` instead — blur hot-reloads immediately via `ghostty +reload-config`.

- **Normal mode** (`ghostty-transparency`): `background-blur = false` — transparent, no blur
- **Presentation mode** (`ghostty-transparency`): `background-blur = true` — blurs the background, improving contrast without touching opacity
- **Custom value** (`ghostty-transparency macos-glass-regular`): supports any valid blur value, including macOS 26 native glass effects

Adds `background-blur = false` explicitly to the base Ghostty config so the sed replacement has a line to target.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wed3ZczKuPX9T5H6c4nMgz)_