### PR TITLE
Apply ghostty transparency changes without restart using osascript split trick

### DIFF
--- a/shell.d/alias.Darwin
+++ b/shell.d/alias.Darwin
@@ -20,7 +20,5 @@ ghostty-transparency() {
   fi
 
   sed -i '' "s/^background-blur = .*/background-blur = ${new_blur}/" "$config"
-  echo "Ghostty: background-blur set to ${new_blur}"
-
-  ghostty +reload-config 2>/dev/null && echo "Config reloaded. ✅" || echo "⚠️ Reload manually with ctrl+shift+, "
+  echo "Ghostty: background-blur set to ${new_blur} — restart Ghostty to apply."
 }

--- a/shell.d/alias.Darwin
+++ b/shell.d/alias.Darwin
@@ -20,5 +20,17 @@ ghostty-transparency() {
   fi
 
   sed -i '' "s/^background-blur = .*/background-blur = ${new_blur}/" "$config"
-  echo "Ghostty: background-blur set to ${new_blur} — restart Ghostty to apply."
+  echo "Ghostty: background-blur set to ${new_blur}"
+
+  # Transparency changes apply on reload only when a split is open (ghostty#3109).
+  # Open a temporary split, reload config, then close it.
+  if osascript -e 'tell application "System Events" to tell process "Ghostty" to keystroke "d" using command down' 2>/dev/null; then
+    sleep 0.4
+    osascript -e 'tell application "System Events" to tell process "Ghostty" to keystroke "," using {command down, shift down}' 2>/dev/null
+    sleep 0.2
+    osascript -e 'tell application "System Events" to tell process "Ghostty" to keystroke "w" using command down' 2>/dev/null
+    echo "Config reloaded."
+  else
+    echo "Grant Accessibility access, or: open a split (cmd+d), reload (cmd+shift+,), close split (cmd+w)."
+  fi
 }

--- a/shell.d/alias.Darwin
+++ b/shell.d/alias.Darwin
@@ -20,7 +20,7 @@ ghostty-transparency() {
   fi
 
   sed -i '' "s/^background-blur = .*/background-blur = ${new_blur}/" "$config"
-  echo "Ghostty: background-blur set to ${new_blur}"
+  echo "🔲 Ghostty: background-blur set to ${new_blur}"
 
   # Transparency changes apply on reload only when a split is open (ghostty#3109).
   # Open a temporary split, reload config, then close it.
@@ -29,8 +29,8 @@ ghostty-transparency() {
     osascript -e 'tell application "System Events" to tell process "Ghostty" to keystroke "," using {command down, shift down}' 2>/dev/null
     sleep 0.2
     osascript -e 'tell application "System Events" to tell process "Ghostty" to keystroke "w" using command down' 2>/dev/null
-    echo "Config reloaded."
+    echo "✅ Config reloaded."
   else
-    echo "Grant Accessibility access, or: open a split (cmd+d), reload (cmd+shift+,), close split (cmd+w)."
+    echo "⚠️  Grant Accessibility access, or: open a split (cmd+d), reload (cmd+shift+,), close split (cmd+w)."
   fi
 }


### PR DESCRIPTION
Per [ghostty#3109](https://github.com/ghostty-org/ghostty/issues/3109#issuecomment-4130144959), transparency settings apply on config reload when a split is open — no full restart required.

`ghostty-transparency` now automates the workaround via `osascript`:
1. Opens a temporary split (`cmd+d`)
2. Triggers a config reload (`cmd+shift+,`)
3. Closes the split (`cmd+w`)

Falls back with manual instructions if Accessibility access isn't granted to the calling app.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wed3ZczKuPX9T5H6c4nMgz)_