### PR TITLE
Fix 1Password template syntax for ANTHROPIC_API_KEY

### DIFF
--- a/shell.d/env.vim-ai.tmpl
+++ b/shell.d/env.vim-ai.tmpl
@@ -1,1 +1,1 @@
-export ANTHROPIC_API_KEY="{{ (onepasswordDetailsFields "l26vtdxoguuassebp3iohrbdma" "" "dyz4dyfpyrte2nesqaerlhqlkq").credential.value }}"
+export ANTHROPIC_API_KEY="{{ (onepasswordDetailsFields "l26vtdxoguuassebp3iohrbdma").credential.value }}"


### PR DESCRIPTION
Remove unnecessary vault and account UUID parameters from the `onepasswordDetailsFields` function call in the ANTHROPIC_API_KEY template.

## Summary
The `onepasswordDetailsFields` function only requires the item UUID as a parameter. The vault and account UUIDs are optional and can cause "no 1Password account found" errors if incorrectly specified.

## Changes
- Simplified the `onepasswordDetailsFields` call to use only the item UUID, removing the empty vault and account UUID parameters

This aligns with the guidance in CLAUDE.md that the item UUID alone is sufficient for the function to work correctly.

https://claude.ai/code/session_01GCpNarRYfG2md4CG59XAhb