### PR TITLE
Add Stripe and HTTP client snippets to Go UltiSnips

### DIFF
--- a/dot_vim/UltiSnips/go.snippets
+++ b/dot_vim/UltiSnips/go.snippets
@@ -227,3 +227,59 @@ snippet thenc "LINT.ThenChange end marker" b
 // LINT.ThenChange(${1:path/to/other/file.go})
 ${0}
 endsnippet
+
+# ── Stripe / HTTP client ─────────────────────────────────────────────────────
+
+snippet htclient "HTTP client with timeout" b
+httpClient := &http.Client{
+	Timeout: ${1:10} * time.Second,
+}
+$0
+endsnippet
+
+snippet sclient "Stripe client init" b
+stripe.Key = os.Getenv("STRIPE_SECRET_KEY")
+$0
+endsnippet
+
+snippet serr "Stripe error handling" b
+if err != nil {
+	if stripeErr, ok := err.(*stripe.Error); ok {
+		switch stripeErr.Code {
+		case stripe.ErrorCodeRateLimit:
+			// back off and retry
+		case stripe.ErrorCodeInvalidRequest:
+			// bad params — don't retry
+		default:
+			// unexpected stripe error
+		}
+	}
+	return fmt.Errorf("stripe call failed: %w", err)
+}
+$0
+endsnippet
+
+snippet jdec "JSON decode response body" b
+defer ${1:resp}.Body.Close()
+var result ${2:MyStruct}
+if err := json.NewDecoder($1.Body).Decode(&result); err != nil {
+	return fmt.Errorf("decode response: %w", err)
+}
+$0
+endsnippet
+
+snippet smain "main with env key check" b
+func main() {
+	apiKey := os.Getenv("STRIPE_SECRET_KEY")
+	if apiKey == "" {
+		log.Fatal("STRIPE_SECRET_KEY not set")
+	}
+	stripe.Key = apiKey
+	$0
+}
+endsnippet
+
+snippet idem "Stripe idempotency key" b
+params.Params.IdempotencyKey = stripe.NewIdempotencyKey()
+$0
+endsnippet


### PR DESCRIPTION
Add a collection of UltiSnips for common Go patterns when working with Stripe and HTTP clients.

**Changes:**
- `htclient` — HTTP client initialization with configurable timeout
- `sclient` — Stripe client setup from environment variable
- `serr` — Stripe error handling with type assertion and error code switching
- `jdec` — JSON response body decoding with error handling
- `smain` — Main function with STRIPE_SECRET_KEY validation
- `idem` — Stripe idempotency key generation

These snippets reduce boilerplate when integrating Stripe payments or making HTTP requests in Go projects. Trigger with `<C-e>` and jump between placeholders with `<C-j>`/`<C-k>`.

https://claude.ai/code/session_0175T5PwVBu493YWDc2jsLhY