### PR TITLE
vim: Go snippets, filetype templates, and dynamic copyright year

### DIFF
--- a/dot_vim/templates/go.tpl
+++ b/dot_vim/templates/go.tpl
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("hello")
+}

--- a/dot_vim/templates/go.tpl.tmpl
+++ b/dot_vim/templates/go.tpl.tmpl
@@ -1,3 +1,5 @@
+// Copyright (c) {{ now | date "2006" }}, Conall O'Brien
+
 package main
 
 import (

--- a/dot_vim/templates/py.tpl.tmpl
+++ b/dot_vim/templates/py.tpl.tmpl
@@ -3,7 +3,7 @@
 
 # $Id$
 
-# Copyright (c) 2024, Conall O'Brien
+# Copyright (c) {{ now | date "2006" }}, Conall O'Brien
 # Released under the BSD license
 #
 # Redistribution and use in source and binary forms, with or without

--- a/dot_vim/templates/sh.tpl.tmpl
+++ b/dot_vim/templates/sh.tpl.tmpl
@@ -3,7 +3,7 @@
 
 # $Id$
 
-# Copyright (c) 2024, Conall O'Brien
+# Copyright (c) {{ now | date "2006" }}, Conall O'Brien
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
## Summary

- Adds Stripe/HTTP client UltiSnips snippets to `go.snippets` (`htclient`, `sclient`, `serr`, `jdec`, `smain`, `idem`)
- Adds `go.tpl` filetype template so new `.go` files open pre-populated with `package main`, a `fmt` import, and a `main()` stub
- Converts all three vim filetype templates (`go.tpl`, `py.tpl`, `sh.tpl`) to chezmoi templates so the copyright year is rendered dynamically at `chezmoi apply` time

---
_Generated by [Claude Code](https://claude.ai/code/session_0175T5PwVBu493YWDc2jsLhY)_