### PR TITLE
vim: fix main redeclared error; shell: add STRIPE_SECRET_KEY

### DIFF
--- a/dot_vim/templates/go.tpl.tmpl
+++ b/dot_vim/templates/go.tpl.tmpl
@@ -1,11 +1,1 @@
-// Copyright (c) {{ now | date "2006" }}, Conall O'Brien
-
 package main
-
-import (
-	"fmt"
-)
-
-func main() {
-	fmt.Println("hello")
-}

--- a/dot_vim/templates/main.go.tpl.tmpl
+++ b/dot_vim/templates/main.go.tpl.tmpl
@@ -1,0 +1,11 @@
+// Copyright (c) {{ now | date "2006" }}, Conall O'Brien
+
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("hello")
+}

--- a/dot_vim/vimrc
+++ b/dot_vim/vimrc
@@ -858,9 +858,19 @@ au BufNewFile,BufRead .mutt_* so $VIMRUNTIME/syntax/muttrc.vim
 " ============================================================================
 " Templates for New Files
 " ============================================================================
+function! s:LoadTemplate() abort
+  let l:by_name = $HOME . '/.vim/templates/' . expand('%:t') . '.tpl'
+  let l:by_ext  = $HOME . '/.vim/templates/' . expand('%:e') . '.tpl'
+  if filereadable(l:by_name)
+    execute '0r ' . fnameescape(l:by_name)
+  elseif filereadable(l:by_ext)
+    execute '0r ' . fnameescape(l:by_ext)
+  endif
+endfunction
+
 augroup BufNewFileFromTemplate
 au!
-autocmd BufNewFile * silent! 0r $HOME/.vim/templates/%:e.tpl
+autocmd BufNewFile * call s:LoadTemplate()
 autocmd BufNewFile * normal! G"_dd1G
 autocmd BufNewFile * silent! match Todo /TODO/
 augroup END

--- a/shell.d/env.Darwin.tmpl
+++ b/shell.d/env.Darwin.tmpl
@@ -5,3 +5,5 @@ export PATH="${PATH}:/opt/homebrew/bin:~/bin"
 
 # Use the 1Password SSH Agent
 export SSH_AUTH_SOCK=~/.ssh/1password.agent.sock
+
+export STRIPE_SECRET_KEY="{{ (onepasswordDetailsFields "gpnkrvi5we2stwqnik5lyv2q4e").credential.value }}"


### PR DESCRIPTION
## Summary

- Fixes `main redeclared` gopls error when opening non-`main.go` Go files by splitting the vim template into `main.go.tpl` (full boilerplate) and `go.tpl` (just `package main`). Updates the vimrc loader to prefer filename-specific templates over extension-based ones.
- Converts `shell.d/env.Darwin` to a chezmoi template and adds `STRIPE_SECRET_KEY` sourced from 1Password item `gpnkrvi5we2stwqnik5lyv2q4e`, consistent with how `ANTHROPIC_API_KEY` is managed.

---
_Generated by [Claude Code](https://claude.ai/code/session_0175T5PwVBu493YWDc2jsLhY)_