### PR TITLE
Add git workflow guidance for stacked PRs

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -40,6 +40,7 @@
 * When working in a git repository, if the most recently opened PR/MR for the current branch has already been merged and further instructions are given, always create a new branch before making further changes — never stack new commits onto a branch whose PR has already merged
   - This keeps history clean and allows a subsequent PR/MR to be opened for the new work
   - Base the new branch on the latest default branch (e.g. `main`)
+  - In effect, this produces a stacked-diff workflow: each PR/MR builds on the previous, already-merged one rather than piling unrelated changes onto a single long-lived branch
 
 # Agents
 

--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -36,6 +36,11 @@
     ```
     ```
 
+# Git Usage
+* When working in a git repository, if the most recently opened PR/MR for the current branch has already been merged and further instructions are given, always create a new branch before making further changes — never stack new commits onto a branch whose PR has already merged
+  - This keeps history clean and allows a subsequent PR/MR to be opened for the new work
+  - Base the new branch on the latest default branch (e.g. `main`)
+
 # Agents
 
 Specialised agents are defined in `~/.claude/agents/`. Use them for:


### PR DESCRIPTION
Add documentation to CLAUDE.md clarifying git workflow best practices when working with stacked changes.

## Summary
Added a new "Git Usage" section to provide guidance on handling situations where a PR/MR for the current branch has already been merged but further work is needed.

## Key Changes
- Document the requirement to create a new branch before making further changes after a PR has merged
- Explain the rationale: keeping history clean and allowing subsequent PRs to be opened for new work
- Specify that new branches should be based on the latest default branch (e.g., `main`)

This guidance complements the existing "Git Workflow" section and helps maintain clean commit history in this personal dotfiles repository.

https://claude.ai/code/session_014bVGvDfN7XUi1iTg8s8Z64