### PR TITLE
Make 1Password SSH agent socket path dynamic

### DIFF
--- a/Library/LaunchAgents/com.1password.SSH_AUTH_SOCK.plist
+++ b/Library/LaunchAgents/com.1password.SSH_AUTH_SOCK.plist
@@ -9,7 +9,7 @@
   <array>
     <string>/bin/sh</string>
     <string>-c</string>
-    <string>/bin/ln -sf $HOME/Library/Group\ Containers/2BUA8C4S2C.com.1password/t/agent.sock \$SSH_AUTH_SOCK</string>
+    <string>for s in "$HOME"/Library/Group\ Containers/*.com.1password/t/agent.sock; do [ -S "$s" ] &amp;&amp; /bin/ln -sf "$s" "$HOME/.ssh/1password.agent.sock" &amp;&amp; break; done</string>
   </array>
   <key>RunAtLoad</key>
   <true/>

--- a/shell.d/env.Darwin.tmpl
+++ b/shell.d/env.Darwin.tmpl
@@ -3,17 +3,21 @@
 # Support Homebrew and user specific bin directories
 export PATH="${PATH}:/opt/homebrew/bin:~/bin"
 
-# Use the 1Password SSH Agent. The Group Container's UUID prefix
-# (currently 2BUA8C4S2C) is assigned by macOS at install time and isn't
-# guaranteed to stay constant, so glob for it instead of hardcoding it.
-# The (N) qualifier makes the glob expand to nothing (rather than erroring)
+# Use the 1Password SSH Agent, kept behind the same predictable
+# ~/.ssh/1password.agent.sock path used for remote agent forwarding
+# (see shell.d/env.ssh-agent's ~/.ssh/agent-forwarded). The Group
+# Container's UUID prefix (currently 2BUA8C4S2C) is assigned by macOS at
+# install time and isn't guaranteed to stay constant, so glob for the
+# real socket and re-point the symlink at it on every shell start. The
+# (N) qualifier makes the glob expand to nothing (rather than erroring)
 # if 1Password isn't installed or hasn't created the socket yet.
 for op_ssh_sock in "$HOME"/Library/Group\ Containers/*.com.1password/t/agent.sock(N); do
   if [ -S "$op_ssh_sock" ]; then
-    export SSH_AUTH_SOCK="$op_ssh_sock"
+    ln -sf "$op_ssh_sock" ~/.ssh/1password.agent.sock
     break
   fi
 done
 unset op_ssh_sock
+export SSH_AUTH_SOCK=~/.ssh/1password.agent.sock
 
 export STRIPE_SECRET_KEY="{{ (onepasswordDetailsFields "gpnkrvi5we2stwqnik5lyv2q4e").credential.value }}"

--- a/shell.d/env.Darwin.tmpl
+++ b/shell.d/env.Darwin.tmpl
@@ -3,7 +3,17 @@
 # Support Homebrew and user specific bin directories
 export PATH="${PATH}:/opt/homebrew/bin:~/bin"
 
-# Use the 1Password SSH Agent
-export SSH_AUTH_SOCK=~/.ssh/1password.agent.sock
+# Use the 1Password SSH Agent. The Group Container's UUID prefix
+# (currently 2BUA8C4S2C) is assigned by macOS at install time and isn't
+# guaranteed to stay constant, so glob for it instead of hardcoding it.
+# The (N) qualifier makes the glob expand to nothing (rather than erroring)
+# if 1Password isn't installed or hasn't created the socket yet.
+for op_ssh_sock in "$HOME"/Library/Group\ Containers/*.com.1password/t/agent.sock(N); do
+  if [ -S "$op_ssh_sock" ]; then
+    export SSH_AUTH_SOCK="$op_ssh_sock"
+    break
+  fi
+done
+unset op_ssh_sock
 
 export STRIPE_SECRET_KEY="{{ (onepasswordDetailsFields "gpnkrvi5we2stwqnik5lyv2q4e").credential.value }}"


### PR DESCRIPTION
## Summary

Updates the 1Password SSH agent socket configuration to dynamically locate the socket instead of relying on a hardcoded UUID path. This ensures the configuration continues to work across 1Password updates that may change the Group Container UUID.

## Changes

- **shell.d/env.Darwin.tmpl**: Replace hardcoded 1Password socket path with a glob-based lookup that:
  - Searches for the socket in `~/Library/Group Containers/*.com.1password/t/agent.sock`
  - Creates/updates a symlink at `~/.ssh/1password.agent.sock` pointing to the discovered socket
  - Gracefully handles cases where 1Password isn't installed or hasn't created the socket yet using the `(N)` glob qualifier
  - Includes detailed comments explaining the UUID volatility and symlink strategy

- **Library/LaunchAgents/com.1password.SSH_AUTH_SOCK.plist**: Update the launch agent to use the same dynamic socket discovery logic, ensuring consistency between shell initialization and system launch agent behavior

## Implementation Details

The solution uses a `for` loop with glob expansion to find the 1Password socket, checks that it's a valid socket file with `-S`, and maintains a predictable symlink path (`~/.ssh/1password.agent.sock`) for SSH agent forwarding. This decouples the configuration from 1Password's internal UUID assignment, which macOS assigns at install time and may change across updates.

https://claude.ai/code/session_01LfDjVU7p9TQ4PNG6UfMFLj