### PR TITLE
Add promql-cody agent and o11y-analysis-tools skills

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -60,3 +60,15 @@ Specialised agents are defined in `~/.claude/agents/`. Use them for:
 * `incident-response` — incident triage, log analysis, and incident.io coordination (work only)
 * `go-repo-setup` — scaffold a new Go GitHub repo with CI, release process, goreleaser, Makefile, and standard structure
 * `financial-planning` — pension tracking, spending analysis via Toshl, and personal financial planning
+* `promql-cody` — PromQL/Alertmanager rule maintenance via the o11y-analysis-tools CLIs (formatting, label-checking, test scaffolding, notification previews, hysteresis tuning, stale-alert cleanup)
+
+# Skills
+
+Additional skills from [o11y-analysis-tools](https://github.com/conallob/o11y-analysis-tools) are defined in `~/.claude/skills/`:
+* `promql-cody` — orchestrates all six PromQL/Alertmanager tools below; load this first to decide which tool fits a given request
+* `promql-fmt` — format/lint PromQL multiline expressions (hermetic, CI-safe)
+* `label-check` — enforce required labels on PromQL expressions (hermetic, CI-safe)
+* `autogen-promql-tests` — scaffold `promtool` unit tests for untested rules (hermetic)
+* `e2e-alertmanager-test` — render end-to-end alert notification previews (hermetic with a skeleton config)
+* `alert-hysteresis` — recommend `for:` duration tuning from live Prometheus history (interactive)
+* `stale-alerts-analyzer` — flag alert rules that rarely/never fire, using live Prometheus history (interactive)

--- a/dot_claude/agents/promql-cody.md
+++ b/dot_claude/agents/promql-cody.md
@@ -1,0 +1,55 @@
+---
+name: promql-cody
+description: PromQL/Alertmanager rule maintenance specialist. Use for formatting, label-checking, test scaffolding, alertmanager notification previews, hysteresis tuning, and stale-alert cleanup using the o11y-analysis-tools CLIs (promql-fmt, label-check, autogen-promql-tests, e2e-alertmanager-test, alert-hysteresis, stale-alerts-analyzer).
+---
+
+Specialist for maintaining Prometheus/Alertmanager rule files with the
+[o11y-analysis-tools](https://github.com/conallob/o11y-analysis-tools) CLI
+suite. Named after and dedicated to the late Cody Smith.
+
+## Tool Selection
+
+Load the matching skill (`~/.claude/skills/<tool>/SKILL.md`) for exact
+flags and output format before invoking a tool. For a request that doesn't
+obviously map to one tool, load `~/.claude/skills/promql-cody/SKILL.md`
+first — it's the map of which tool fits which intent and which are safe
+to automate.
+
+| Task | Tool | Hermetic? |
+|---|---|---|
+| Fix multiline formatting of PromQL expressions | `promql-fmt` | Yes |
+| Enforce required labels (`job`, `namespace`, ...) | `label-check` | Yes |
+| Scaffold `promtool` unit tests for new rules | `autogen-promql-tests` | Yes |
+| Preview alert notifications (email/Slack/JSON) | `e2e-alertmanager-test` | Yes, with a skeleton config |
+| Recommend `for:` duration tuning | `alert-hysteresis` | No — needs live Prometheus history |
+| Flag alerts that rarely/never fire | `stale-alerts-analyzer` | No — needs live Prometheus history |
+
+## Hermetic vs. Interactive
+
+- **Hermetic (CI-safe)**: `promql-fmt --check`, `label-check`,
+  `autogen-promql-tests`, and `e2e-alertmanager-test` when pointed at an
+  ephemeral Alertmanager loaded with a skeleton config (real routing,
+  no-op receivers). Safe to wire into a blocking CI gate.
+- **Interactive (judgment-assisted)**: `alert-hysteresis` and
+  `stale-alerts-analyzer` query a live Prometheus's `ALERTS` history.
+  Never wire these into a merge-blocking gate — run them periodically
+  (e.g. quarterly, or when on-call flags alert fatigue) and have a human
+  review the recommendation before touching production alerting rules.
+
+## Suggested Workflow
+
+1. `promql-fmt --check` (or `--fix`) on changed rule files.
+2. `label-check --labels=job,...` for required-label enforcement.
+3. `autogen-promql-tests --rules=...` the first time a rule is added, then
+   hand-fill the generated `TODO`s.
+4. `promtool test rules ./*_test.yml` to run the generated unit tests.
+5. `e2e-alertmanager-test` against an ephemeral Alertmanager with a
+   skeleton config, producing a diffable notification-preview artifact.
+6. Periodically, `alert-hysteresis` and `stale-alerts-analyzer` against
+   production Prometheus to tune hysteresis and cull dead alerts.
+
+## Installation
+
+Binaries install via Homebrew (`brew install conallob/tap/o11y-analysis-tools`),
+`go install`, or `ghcr.io` container images — see the repo's
+[INSTALLING.md](https://github.com/conallob/o11y-analysis-tools/blob/main/INSTALLING.md).

--- a/dot_claude/skills/alert-hysteresis/SKILL.md
+++ b/dot_claude/skills/alert-hysteresis/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: alert-hysteresis
+description: Query a live Prometheus's historical ALERTS series to statistically recommend better 'for:' hold-down durations, reducing spurious short-lived alerts and alert fatigue. Use interactively when an alert is firing too often/too briefly and needs its hysteresis tuned, or when auditing a rules file's for: values against real firing behavior. Requires a live Prometheus with sufficient ALERTS retention — not hermetic, not a CI check.
+license: BSD-3-Clause
+---
+
+# alert-hysteresis
+
+Analyzes how long alerts have actually stayed firing in the past (via
+Prometheus's `ALERTS{alertname=...}` series) and recommends a `for:`
+duration that would filter out short-lived, non-actionable firings while
+still catching the ones that matter. This is a judgment-assisted,
+interactive tool, not a static analyzer — every run depends on real,
+non-reproducible production history.
+
+## When to use this skill
+
+- On-call has flagged an alert as noisy/flappy and you want a
+  data-driven `for:` recommendation instead of guessing.
+- You're auditing a rules file's existing `for:` values against how the
+  alert has actually behaved in production.
+- **Do not** wire this into CI as a blocking check: its output depends on
+  live Prometheus data that CI can't reproduce deterministically, and the
+  right response to a recommendation is a human decision, not an
+  auto-applied diff (except deliberately, via `--fix`, described below).
+
+## Prerequisites
+
+- A reachable Prometheus (or Thanos/Cortex/Mimir with a Prometheus-
+  compatible `/api/v1/query_range` endpoint) that has been actually
+  evaluating the alerting rules in question, so the `ALERTS` metric has
+  history to query.
+- **Retention matters**: this tool can only see as far back as
+  `--timeframe` *and* as far back as Prometheus has actually retained
+  samples. A `--timeframe=30d` against a Prometheus with 15d retention
+  will silently undercount — always sanity-check retention before trusting
+  a "no data" or thin-sample result.
+
+## Setup
+
+```bash
+go build -o bin/alert-hysteresis ./cmd/alert-hysteresis
+# or: go install github.com/conallob/o11y-analysis-tools/cmd/alert-hysteresis@latest
+```
+
+## Usage
+
+```
+alert-hysteresis [options]
+```
+
+| Flag | Default | Effect |
+|---|---|---|
+| `--prometheus-url` | `http://localhost:9090` | Prometheus API base URL. Required to be reachable — the tool errors out otherwise. |
+| `--alert` | `""` | Restrict analysis to one alert name. Omit to analyze every alert with firing history in the window. |
+| `--timeframe` | `168h` (7d) | Lookback window, any Go duration (`24h`, `72h`, …). |
+| `--rules` | `""` | Path to a rules YAML file — lets the tool compare its recommendation against the *currently configured* `for:` value and only flag a mismatch beyond `--threshold`. Without it, every alert's recommendation is just reported, not flagged as a mismatch. |
+| `--threshold` | `0.2` | Fractional mismatch (vs. configured `for:`) required before flagging a recommendation, e.g. `0.3` = only flag when recommended and configured differ by >30%. |
+| `--target-percentile` | `0.3` | Which percentile of historical firing durations to recommend as the new `for:` (e.g. `0.5` = median). Higher values are more conservative (fewer alerts prevented, less risk of missing a real incident). |
+| `--fix` | `false` | Requires `--rules`. Writes the recommended `for:` values directly into the rules file instead of just printing them. |
+
+### Typical invocations
+
+```bash
+# Survey all alerts over the last 7 days (default)
+alert-hysteresis --prometheus-url=http://prometheus:9090
+
+# Focus on one noisy alert over the last day
+alert-hysteresis --prometheus-url=http://prometheus:9090 --alert=HighErrorRate --timeframe=24h
+
+# Compare against configured values, only flag >30% mismatches
+alert-hysteresis --prometheus-url=http://prometheus:9090 --rules=./alerts.yml --threshold=0.3
+
+# Apply recommendations directly (review the diff before committing!)
+alert-hysteresis --prometheus-url=http://prometheus:9090 --fix --rules=./alerts.yml --target-percentile=0.5
+```
+
+## Reading the output
+
+Per alert: firing count, average/median/P75/P90/min/max durations, the
+configured `for:` (if `--rules` given), and either a `RECOMMENDATION` with
+reasoning and prevented-alert count, or a confirmation that the current
+value is acceptable. A closing summary counts how many alerts need
+adjustment. Exit code `1` if any alert needs adjustment (or, without
+`--rules`, whenever any alert simply has a nonzero recommendation to
+report against — read the summary line to disambiguate "found N alerts
+with recommendations" from "found N alerts that need hysteresis
+adjustment").
+
+## Agent workflow
+
+1. Always pass `--rules` when one exists — without it you only get raw
+   statistics, not an actionable "current vs. recommended" comparison.
+2. Start with the default `--target-percentile=0.3`/`--threshold=0.2` and
+   discuss the tradeoff with the user before changing them: a higher
+   percentile means a longer `for:` (fewer alerts, slower detection); a
+   lower one means faster detection but less spurious-alert filtering.
+3. Prefer printing recommendations and letting a human review the diff
+   over using `--fix` directly, unless the user has explicitly asked for
+   the change to be applied — this tool is tuning production alerting
+   behavior, and a bad `for:` value can hide a real incident.
+4. If results look empty or thin, check Prometheus retention against
+   `--timeframe` before concluding the alert genuinely never fires long
+   enough — that's a job better suited to `stale-alerts-analyzer` anyway.

--- a/dot_claude/skills/autogen-promql-tests/SKILL.md
+++ b/dot_claude/skills/autogen-promql-tests/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: autogen-promql-tests
+description: Identify Prometheus alert/recording rules that have no promtool unit-test coverage, and scaffold true-positive/false-positive/hysteresis test-case skeletons for them. Use when bootstrapping unit tests for new or existing PromQL rules, or auditing test coverage of a rules file. Fully hermetic: reads only local rule/test YAML, no running Prometheus required.
+license: BSD-3-Clause
+---
+
+# autogen-promql-tests
+
+Coverage auditor and test-skeleton generator for Prometheus rule files. It
+does not know your actual metric shapes — it emits a `promtool`-compatible
+test file full of `TODO` placeholders that a human (or an agent that has
+read the real metrics) must fill in with realistic input series and
+expected values. Hermetic — no network access.
+
+## When to use this skill
+
+- A rules file has alerts or recording rules with no corresponding
+  `promtool test rules` coverage, and you want a starting skeleton rather
+  than writing `input_series`/`exp_alerts` blocks from scratch.
+- You want a quick coverage report: how many of N rules currently have
+  tests, and which ones don't.
+- This is a **bootstrap** tool, best run interactively the first time a
+  rule is added — not a CI gate, since its generated output is
+  intentionally incomplete (`TODO` markers) and would fail `promtool test
+  rules` until a human fills them in.
+
+## Setup
+
+```bash
+go build -o bin/autogen-promql-tests ./cmd/autogen-promql-tests
+# or: go install github.com/conallob/o11y-analysis-tools/cmd/autogen-promql-tests@latest
+```
+
+## Usage
+
+```
+autogen-promql-tests [options]
+```
+
+| Flag | Default | Effect |
+|---|---|---|
+| `--rules` | *(required)* | Path to the Prometheus rules YAML file to audit. |
+| `--tests` | `""` | Path to an existing test file to check coverage against. If omitted, the tool auto-discovers `<rules-basename>_test.yml` next to the rules file. |
+| `--fix` | `false` | Generate a test file covering the untested alerts/rules. |
+| `--verbose` | `false` | Print discovery/loading detail. |
+
+### Typical invocations
+
+```bash
+# Coverage report only (exit 1 if anything is untested)
+autogen-promql-tests --rules=./alerts.yml
+
+# Generate a test skeleton for whatever's untested
+autogen-promql-tests --rules=./alerts.yml --fix
+
+# Check against an explicit, non-default-named test file
+autogen-promql-tests --rules=./rules.yml --tests=./custom_tests.yml
+```
+
+Without `--tests`, it looks for `<rules>_test.yml` (rules file's basename
+with `.yml`/`.yaml` stripped, `_test.yml` appended) in the same directory.
+With `--fix`, the same path is the default write target unless `--tests`
+is also given, in which case that path is used both to read *and* write.
+
+## What the generated file contains
+
+For every rule not already covered (`alert:` or `record:` name absent from
+the tested set), it appends four test cases to the output YAML:
+
+1. **True positive** — `input_series` tuned (via a `TODO`) to make the
+   alert fire; asserts `exp_alerts` with the rule's actual `labels:` and a
+   `TODO` placeholder for each `annotations:` template value.
+2. **False positive** — same shape, but `TODO`'d to *not* trigger the
+   condition; asserts `exp_alerts: []`.
+3. **Hysteresis check** — only emitted if the rule has a `for:` duration:
+   evaluates at roughly half the `for:` duration and asserts the alert has
+   **not** fired yet, to test the hold-down timer itself.
+4. **Edge cases** — an empty placeholder section reminding the human to add
+   boundary values, missing-metric behavior, label-combination cases, and
+   recovery behavior.
+
+The `input_series` blocks always start from a single placeholder
+`example_metric{job="test", instance="localhost:9090"}` series with a
+`TODO` — the tool does not parse the expression's actual metric names into
+realistic series, it only echoes the first line of the expression as a
+comment reminder. **An agent should replace these placeholders using the
+real metric names and label sets from the rule's `expr:`.**
+
+## Reading the output
+
+```
+═══════════════════════════════════════════════════════════
+Test Coverage Analysis
+═══════════════════════════════════════════════════════════
+
+Total rules/alerts: 8
+Tested: 5
+Untested: 3
+
+Untested alerts/rules:
+  • HighErrorRate
+  • job:http_requests:rate5m
+  • LowDiskSpace
+
+Run with --fix to generate tests for untested alerts
+```
+
+Exit code `1` when untested rules exist and `--fix` wasn't passed, `0`
+otherwise (including after a successful `--fix` run).
+
+## Agent workflow
+
+1. Run without `--fix` first to see the coverage gap and decide scope.
+2. Run with `--fix` to generate the skeleton file.
+3. **Do not stop there.** Open the generated `_test.yml` and replace every
+   `TODO` with real series data derived from the rule's actual `expr:` —
+   correct metric names, label sets that match what the alert's `labels:`
+   expects, and values that genuinely cross (or stay under) the alerting
+   threshold. The file will not pass `promtool test rules` until this is
+   done.
+4. Verify with `promtool test rules <generated-file>` once filled in.
+5. Re-run `autogen-promql-tests --rules=... --tests=<generated-file>` to
+   confirm the rule now shows as tested.

--- a/dot_claude/skills/e2e-alertmanager-test/SKILL.md
+++ b/dot_claude/skills/e2e-alertmanager-test/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: e2e-alertmanager-test
+description: Render end-to-end previews of what an alert notification will actually look like (plain-text email, HTML email, Slack attachment JSON, raw webhook JSON) by replaying a Prometheus unit-test file's expected alerts through a live Alertmanager. Effectively a "print preview" for alerts. Use to review notification formatting/content before merging alert changes, or in CI against an ephemeral Alertmanager to produce a diffable preview artifact. Requires a reachable Alertmanager API and a promtool-style unit-test file as input. Can be made fully hermetic in CI by pointing the ephemeral Alertmanager at a skeleton config that keeps the team's real routing/grouping/inhibition rules but overrides receiver connection details, so no real notification ever leaves the runner.
+license: BSD-3-Clause
+---
+
+# e2e-alertmanager-test
+
+Takes the `exp_alerts` fixtures out of a Prometheus `promtool`-style unit
+test file, POSTs each one to a real Alertmanager's `/api/v2/alerts`
+endpoint, and renders what the resulting notification would look like in
+several formats. It does not test routing/inhibition logic inside this
+tool itself — it exercises whatever routing your target Alertmanager
+instance is actually configured with, and shows you the rendered output.
+
+## When to use this skill
+
+- Before merging an alert change, to see the actual notification content
+  (subject line, body, Slack attachment) a human on-call would receive —
+  not just "does it fire," but "does it read well."
+- As a CI step against a **throwaway/ephemeral** Alertmanager container,
+  producing a rendered-output artifact that reviewers can diff between
+  runs, the same way a UI snapshot test is diffed. Fed a skeleton config
+  (see below), this run is fully hermetic — see [Achieving full
+  hermeticity in CI](#achieving-full-hermeticity-in-ci).
+- This tool's own external dependency is the Alertmanager instance, not
+  historical data — unlike `alert-hysteresis`/`stale-alerts-analyzer`, it
+  needs no real production history, so a fresh, disposable Alertmanager
+  instance is sufficient and the run is fully reproducible.
+
+## Prerequisites
+
+1. **A Prometheus unit-test file** with `exp_alerts` fixtures — typically
+   the output of `autogen-promql-tests` (see that skill) with real,
+   filled-in labels/annotations, or a hand-written `promtool` test file.
+   Test cases whose `exp_alerts` is empty (asserting "does not fire") are
+   silently skipped — there's nothing to render for those.
+2. **A running Alertmanager** reachable over HTTP, defaulting to
+   `http://localhost:9093`. For CI or local preview, run one disposably:
+   ```bash
+   docker run -d -p 9093:9093 prom/alertmanager
+   ```
+
+## Achieving full hermeticity in CI
+
+The `e2e-alertmanager-test` binary itself is never hermetic on its own —
+it always needs to POST to a real, reachable Alertmanager. But the
+routing config *that Alertmanager instance loads* is entirely under your
+control, and that's where every external dependency can be removed:
+
+1. Treat the team's real `alertmanager.yml` — the one that governs
+   production `route:` and `inhibit_rules:` — as the source of truth for
+   routing/grouping/inhibition logic. That's the logic worth exercising
+   in a test.
+2. Build a **skeleton config** for CI that keeps that routing tree intact
+   but overrides every receiver's connection details — `smtp_smarthost`,
+   Slack `api_url`, PagerDuty/webhook URLs and keys — with local, no-op
+   values. For example, point `smtp_smarthost` at a local SMTP catcher
+   (e.g. MailHog/smtp4dev) instead of the real relay, so the receiver
+   still accepts a connection and the message headers can be rendered and
+   diffed, but no mail actually leaves the runner.
+3. Start the ephemeral Alertmanager for the CI job with the skeleton
+   config, not the real one, and point `--alertmanager-url` at it.
+
+With this setup, the Alertmanager under test still runs the real
+routing/grouping/inhibition rules — so a routing regression still
+surfaces in the diff — but delivery stops at the local catcher: no real
+email, Slack message, or PagerDuty incident is ever created. That's what
+makes this tool's CI output (rendered notification content, including
+SMTP headers) safe to treat as a fully hermetic, deterministic artifact.
+Generating and maintaining the skeleton config (importing the team's
+routing tree while stripping receiver secrets) is on you — this repo
+doesn't ship tooling for that merge/override step, and `--alertmanager-config`
+(below) does not perform it either; it only enriches this tool's own
+rendered output text.
+
+Keep the skeleton config's routing tree in sync with the real one, ideally
+generated from it rather than hand-maintained — if it drifts, a green CI
+run stops guaranteeing anything about production routing.
+
+## Setup
+
+```bash
+go build -o bin/e2e-alertmanager-test ./cmd/e2e-alertmanager-test
+# or: go install github.com/conallob/o11y-analysis-tools/cmd/e2e-alertmanager-test@latest
+```
+
+## Usage
+
+```
+e2e-alertmanager-test [options]
+```
+
+| Flag | Default | Effect |
+|---|---|---|
+| `--tests` | *(required)* | Path to the Prometheus unit-test YAML file to replay. |
+| `--alertmanager-url` | `http://localhost:9093` | Alertmanager API base URL to POST alerts to. |
+| `--alertmanager-config` | `""` | Optional path to `alertmanager.yml` — used only to enrich rendered output (e.g. `smtp_from`, receiver name in the routing-info footer), not to actually apply routing rules locally. |
+| `--output` | `email` | One of `email`, `email-html`, `slack`, `json`, `full`. |
+| `--full` | `false` | Also render the HTML body inside `email`/`email-html` output. |
+| `--verbose` | `false` | Print the Alertmanager URL being posted to per alert. |
+
+### Typical invocations
+
+```bash
+# Plain-text email preview
+e2e-alertmanager-test --tests=./alerts_test.yml --output=email
+
+# Full HTML email rendering
+e2e-alertmanager-test --tests=./alerts_test.yml --output=email-html --full
+
+# Slack attachment JSON preview
+e2e-alertmanager-test --tests=./alerts_test.yml --output=slack
+
+# Everything, redirected to a diffable artifact for CI
+e2e-alertmanager-test --tests=./alerts_test.yml --output=full > notifications.txt
+```
+
+## Reading the output
+
+Each test case with non-empty `exp_alerts` becomes one numbered "Test #N",
+printing the alert name and then the rendered output in the requested
+format(s), followed by a summary:
+
+```
+═══════════════════════════════════════════════════════════
+Summary
+═══════════════════════════════════════════════════════════
+Total test cases: 3
+Successful: 3
+Failed: 0
+```
+
+Exit code `1` if any alert failed to POST successfully (e.g. Alertmanager
+unreachable or returned non-200), `0` otherwise. Note: "successful" here
+means the POST to Alertmanager succeeded, not that routing/inhibition
+matched any particular expectation — this tool doesn't assert routing
+outcomes, it only renders notification content.
+
+## Agent workflow
+
+1. Confirm a unit-test file with real (non-`TODO`) `exp_alerts` exists —
+   if not, point the user at `autogen-promql-tests` first.
+2. Confirm an Alertmanager is reachable at `--alertmanager-url` (start a
+   disposable one via Docker if none is running and this is a local/CI
+   context). **Never point this at a production Alertmanager** — it really
+   posts alerts, and a receiver with live connection details will really
+   dispatch them. For CI, load the disposable instance with a [skeleton
+   config](#achieving-full-hermeticity-in-ci) that keeps real
+   routing/grouping/inhibition but swaps receiver connection details for
+   local no-op ones, so the run stays hermetic even though it exercises
+   real routing logic.
+3. Run with `--output=full` to capture every rendering for a
+   comprehensive review, or `--output=slack`/`--output=email-html` when a
+   user specifically wants to review one channel's format.
+4. For CI: redirect output to a file and store it as a build artifact so
+   subsequent runs can be diffed to catch unintended notification-content
+   regressions from template/label changes.

--- a/dot_claude/skills/label-check/SKILL.md
+++ b/dot_claude/skills/label-check/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: label-check
+description: Enforce that PromQL expressions (and, optionally, alert definitions) carry a required set of labels — e.g. job, namespace, cluster — to prevent label collisions in multi-tenant Prometheus/Thanos/Cortex/Mimir setups. Use when validating rule YAML for required labels or required alert labels, interactively or as a CI gate. Fully hermetic: no network access or running Prometheus required.
+license: BSD-3-Clause
+---
+
+# label-check
+
+Static validator that scans `expr:`/`query:` fields (and, in
+`--check-alerts` mode, alert `labels:` blocks) for a required set of label
+names. Hermetic — reads only the files/stdin you give it.
+
+## When to use this skill
+
+- A monitoring platform is multi-tenant and needs every rule to carry a
+  tenant-scoping label (commonly `job`, sometimes `namespace`/`cluster`) to
+  avoid one team's alert matching another team's series.
+- You want a CI gate that fails a PR if a new/edited rule omits a required
+  label.
+- You want to enforce that every alert also carries required *alert*
+  labels (see the important caveat below about what `--alert-labels`
+  actually inspects).
+
+## Setup
+
+```bash
+go build -o bin/label-check ./cmd/label-check
+# or: go install github.com/conallob/o11y-analysis-tools/cmd/label-check@latest
+```
+
+## Usage
+
+```
+label-check [options] <file|directory>...
+```
+
+Accepts `.yml`/`.yaml` files, directories (walked recursively), **or**
+stdin via a literal `-` argument (e.g. for pre-commit hooks piping a
+single expression).
+
+| Flag | Default | Effect |
+|---|---|---|
+| `--labels` | `job` | Comma-separated required labels checked against every PromQL expression. |
+| `--check-alerts` | `false` | Also validate each `- alert: Name` block's `labels:` section. |
+| `--alert-labels` | `""` | Comma-separated labels required in each alert's `labels:` section. Only takes effect with `--check-alerts`. |
+
+### Typical invocations
+
+```bash
+# Default: require 'job' on every expression
+label-check --check ./alerts/
+
+# Multiple required labels
+label-check --labels=job,namespace,cluster ./alerts/
+
+# Also require alert-level labels
+label-check --check-alerts --alert-labels=severity,team ./alerts/
+
+# Single expression via stdin (e.g. pre-commit hook on a diff hunk)
+echo 'rate(http_requests_total[5m])' | label-check --labels=job -
+```
+
+## Important gotchas
+
+- **`--alert-labels` checks the alert's `labels:` block, not
+  `annotations:`.** The CLI's own `-h` example (`--alert-labels=severity,
+  grafana_url,runbook`) is misleading here: `runbook` and `grafana_url`
+  conventionally live under `annotations:`, not `labels:`, so checking for
+  them with this flag will always report them missing even when they're
+  correctly set as annotations. Only use `--alert-labels` for names that
+  are genuinely emitted as alert **labels** (e.g. `severity`, `team`,
+  `tier`); it has no way to validate `annotations:`.
+- **Label detection is regex-based**, not a full PromQL parse. It counts a
+  label as "present" if it appears either in a `{label="..."}`/`label=~"..."`
+  matcher **or** in a `by (...)`/`without (...)` clause anywhere in the
+  expression. That means `sum(metric) by (job)` counts as having the `job`
+  label even though `job` there is a grouping key, not a selector — the
+  underlying series could still span multiple jobs. Don't treat a pass as
+  a hard guarantee against label collisions; treat it as a lint, and read
+  the actual expression when the stakes are high (e.g. an alert routed by
+  tenant).
+- There is **no config-file support** (`.label-check.yml`) despite it being
+  mentioned in the repo's top-level README — as of this version, required
+  labels can only be supplied via `--labels`/`--alert-labels` flags on
+  every invocation. If a user asks for config-file support, tell them it's
+  aspirational/undocumented-in-code, not implemented.
+
+## Reading the output
+
+```
+./alerts/api-alerts.yml:
+  Expression: rate(http_requests_total[5m])
+    Missing required labels: job
+    Line: 12
+
+Found 1 expressions with missing required labels
+Required labels: job
+```
+
+Exit code `1` if any violation is found (expression-level or, with
+`--check-alerts`, alert-level), `0` otherwise.
+
+## Agent workflow
+
+1. Determine the required label set from repo conventions (check for a CI
+   workflow invoking `label-check` already, or ask the user) rather than
+   assuming the `job`-only default is sufficient for a multi-tenant setup.
+2. Run `label-check --labels=<...> <path>`. There is no `--fix` mode — the
+   agent must manually edit the flagged expression to add the missing
+   label matcher, using the printed `Line:` number to locate it, then
+   re-run to confirm.
+3. Only add `--check-alerts --alert-labels=...` when the required names are
+   confirmed to be alert **labels** in this rule set, not annotations —
+   check an existing alert's `labels:` block for the convention first.

--- a/dot_claude/skills/promql-cody/SKILL.md
+++ b/dot_claude/skills/promql-cody/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: promql-cody
+description: Orchestrate all six o11y-analysis-tools PromQL/Alertmanager CLIs together as one workflow for a repo of Prometheus/Alertmanager rules — decide which tools are hermetic and CI-safe (promql-fmt, label-check, autogen-promql-tests, and e2e-alertmanager-test when given a skeleton Alertmanager config) versus interactive-only and judgment-assisted (alert-hysteresis, stale-alerts-analyzer), and in what order to run them end to end. Use this as the entry point whenever a user asks to format, validate, test, preview, tune, or clean up PromQL/Alertmanager rules in this repo — load it before reaching for an individual tool's skill so the right tool and the right mode (interactive vs. CI) get picked. Named after and dedicated to the late Cody Smith.
+license: BSD-3-Clause
+---
+
+# PromQL-Cody
+
+> **In memoriam.** This skill is named after and dedicated to the late
+> [Cody Smith](https://supah.green)
+
+PromQL-Cody is the unified Agent Skill for `o11y-analysis-tools`: it
+teaches an agent how to use all six PromQL/Alertmanager CLIs in this repo
+together — which are safe to run unattended, which need a human in the
+loop, and what order they belong in. Load the per-tool skill
+(`skills/<tool>/SKILL.md`) for the exact flags and output format of
+whichever tool this points you at; this skill is the map, not the detail.
+
+## The six tools at a glance
+
+| Skill | Purpose | Hermetic? | Best run | External dependency |
+|---|---|---|---|---|
+| [`promql-fmt`](../promql-fmt/SKILL.md) | Format/validate PromQL multiline style + best-practice lint | Yes | Interactive **and** CI | none |
+| [`label-check`](../label-check/SKILL.md) | Enforce required labels on expressions/alerts | Yes | Interactive **and** CI | none |
+| [`autogen-promql-tests`](../autogen-promql-tests/SKILL.md) | Generate `promtool`-style unit test skeletons | Yes | Interactive, to bootstrap coverage | none |
+| [`e2e-alertmanager-test`](../e2e-alertmanager-test/SKILL.md) | Render alert notifications (email/Slack/JSON) end-to-end — a "print preview" for alerts | Yes\*, with a skeleton config (see its skill) | CI, producing a diffable artifact; also useful interactively | an ephemeral Alertmanager + a Prometheus unit-test file |
+| [`alert-hysteresis`](../alert-hysteresis/SKILL.md) | Recommend `for:` duration tuning from real firing history | No | Interactive, as needed | live Prometheus with historical `ALERTS` data |
+| [`stale-alerts-analyzer`](../stale-alerts-analyzer/SKILL.md) | Flag alerts that rarely/never fire — "dead code analysis" for alerts | No | Interactive, periodic cleanup | live Prometheus with historical `ALERTS` data |
+
+\* Only when its ephemeral Alertmanager is loaded with a skeleton config
+that overrides receiver connection details. Pointed at a real/unmodified
+Alertmanager config, it can dispatch real notifications and is not
+hermetic.
+
+## Two families of tools
+
+**1. Hermetic static analyzers** — `promql-fmt`, `label-check`,
+`autogen-promql-tests`. These are pure functions over the rule files on
+disk: same input, same output, every time. They need no network access and
+no running Prometheus. This makes them safe to run unattended and to wire
+into CI as required, blocking checks on every commit or pull request.
+
+**2. Historical-data tools** — `alert-hysteresis`, `stale-alerts-analyzer`.
+Both query a live Prometheus's `ALERTS` metric over `--timeframe`/
+`--timehorizon` to reason about *real* firing behavior. Their output is
+only as trustworthy as Prometheus's retention window (an alert can look
+"stale" simply because the lookback exceeds retention). They are not
+reproducible in CI — there's no fixture that substitutes for months of
+real production firing patterns — so treat them as interactive,
+judgment-assisted tools you run during an alert-quality review, not as a
+merge-blocking gate.
+
+`e2e-alertmanager-test` needs a live Alertmanager to POST alerts to, but
+that instance can be a short-lived container, and — unlike the two tools
+above — its output doesn't depend on irreproducible production history.
+Point that ephemeral Alertmanager at a **skeleton config** that preserves
+the team's real `route:`/`inhibit_rules:` but overrides every receiver's
+connection details (SMTP smarthost, Slack/webhook URLs) with local no-op
+values, and the whole run becomes fully hermetic: real routing logic is
+still exercised, but no notification ever leaves the runner. That's what
+makes it safe to run in CI — its payoff there is a generated
+notification-preview artifact that reviewers can diff release over
+release, the way a snapshot test diffs UI screenshots. See the
+[`e2e-alertmanager-test` skill](../e2e-alertmanager-test/SKILL.md#achieving-full-hermeticity-in-ci)
+for how to build that skeleton config.
+
+## Suggested workflow
+
+1. Author or edit alert/recording rules in `*.yml`.
+2. `promql-fmt --check` (or `--fix`) — formatting gate.
+3. `label-check --labels=job,...` — required-label gate.
+4. `autogen-promql-tests --rules=...` — interactively, the first time a rule
+   is added, to scaffold a `_test.yml` (then hand-fill the `TODO`s).
+5. `promtool test rules ./*_test.yml` — run the generated unit tests.
+6. `e2e-alertmanager-test --tests=... --output=full` against an ephemeral
+   Alertmanager loaded with a skeleton config in CI — produces a diffable
+   notification-preview artifact without sending any real notification.
+7. Periodically (e.g. quarterly, or when on-call flags alert fatigue), run
+   `alert-hysteresis` and `stale-alerts-analyzer` interactively against
+   production Prometheus to tune `for:` durations and cull dead alerts.
+
+Steps 2–3 (and 6, given a disposable Alertmanager) belong in CI. Steps 4 and
+7 are deliberately interactive — they either need a human to fill in
+generated placeholders or a human to interpret a statistical recommendation
+before touching production alerting.
+
+## Agent workflow
+
+1. When a user's request touches PromQL/Alertmanager rules in this repo,
+   start here rather than guessing which of the six tools applies — match
+   their intent (format? validate labels? bootstrap tests? preview a
+   notification? investigate a noisy alert? find dead alerts?) against the
+   table above.
+2. Load the specific `skills/<tool>/SKILL.md` for the tool(s) that match
+   before invoking anything — it has the exact flags, output format, and
+   exit-code semantics this skill deliberately omits.
+3. Default hermetic tools (`promql-fmt`, `label-check`, `autogen-promql-tests`,
+   `e2e-alertmanager-test` with a skeleton config) to CI-safe, automatable
+   usage. Default the two historical-data tools to interactive use with a
+   human reviewing the recommendation — never wire them into a
+   merge-blocking gate.
+4. For install/setup instructions (this skill, the six tool skills, or the
+   binaries themselves via Homebrew/`go install`/`ghcr.io` containers), see
+   [`INSTALLING.md`](../../INSTALLING.md) and [`AGENTS.md`](../../AGENTS.md)
+   at the repo root.

--- a/dot_claude/skills/promql-fmt/SKILL.md
+++ b/dot_claude/skills/promql-fmt/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: promql-fmt
+description: Format and lint PromQL expressions embedded in Prometheus/Thanos/Cortex/Mimir rule YAML files — multiline layout, redundant aggregation-clause removal, aggregation-style consistency, and naming/instrumentation best-practice checks. Use whenever writing, editing, or reviewing alert/recording rule YAML, or as a CI formatting gate on pull requests that touch rule files. Fully hermetic: no network access or running Prometheus required.
+license: BSD-3-Clause
+---
+
+# promql-fmt
+
+Static analyzer and auto-formatter for PromQL `expr:`/`query:` fields inside
+Prometheus-style rule YAML files. Hermetic — it only reads the files you
+point it at.
+
+## When to use this skill
+
+- A user is authoring or editing a Prometheus/Thanos/Cortex/Mimir alert or
+  recording rule and wants it formatted consistently.
+- You're reviewing a diff to rule YAML and want to catch style or
+  best-practice violations before commit.
+- You're wiring a CI job that should fail a PR touching rule files with
+  inconsistent formatting.
+
+## Setup
+
+```bash
+go build -o bin/promql-fmt ./cmd/promql-fmt
+# or: go install github.com/conallob/o11y-analysis-tools/cmd/promql-fmt@latest
+```
+
+## Usage
+
+```
+promql-fmt [options] <file|directory>...
+```
+
+Only `.yml`/`.yaml` files are scanned; directories are walked recursively.
+There is no stdin mode (unlike `label-check`) — always pass a file or
+directory path.
+
+| Flag | Default | Effect |
+|---|---|---|
+| `--check` | `true` | Report issues, exit 1 if any found. Do not modify files. |
+| `--fix` / `--fmt` | `false` | Rewrite files in place with the formatted output. `--fmt` is an alias for `--fix`. Passing either disables `--check` automatically. |
+| `--verbose` | `false` | Print per-file "Fixing …" lines while fixing. |
+| `--disable-line-length` | `false` | Suppress the "should use multiline formatting" nudge for long lines — useful for recording rules with unavoidably long metric names. |
+| `--prometheus-url` | `""` | Optional. If set, additionally queries that Prometheus for **timeseries continuity** — i.e., flags expressions that reference metrics with no matching series. This is the one *non-hermetic* opt-in check; omit the flag to stay fully offline. |
+
+### Typical invocations
+
+```bash
+# CI gate / pre-commit check (default mode)
+promql-fmt --check ./prometheus/
+
+# Auto-fix in place, then re-check
+promql-fmt --fix ./prometheus/
+
+# Verbose fix, skip line-length nudges for long recording-rule names
+promql-fmt --fix --verbose --disable-line-length ./prometheus/recording-rules.yml
+```
+
+## What it actually checks/fixes
+
+- **Multiline layout**: rewrites long/complex `expr:` blocks into an
+  indented multiline YAML block scalar (`expr: |`), removing a redundant
+  `by (...)` clause from the left operand of a binary expression when both
+  operands share the same aggregation labels, and inserting an explicit
+  `on (...)` vector-matching clause.
+- **Aggregation clause consistency**: detects whether a file predominantly
+  uses postfix (`sum(metric) by (label)`) or prefix
+  (`sum by (label) (metric)`) style and flags expressions that break with
+  the file's dominant style.
+- **Naming conventions**: snake_case metric names, application-name
+  prefixes, base units (warns on `_milliseconds`/`_minutes`/etc., wants
+  `_seconds`), `_total` suffix on counters, `_ratio` instead of raw
+  percentages, `level:metric:operations` naming for recording rules.
+- **Instrumentation patterns**: `rate()`/`irate()` applied to something
+  that doesn't look like a counter, division without zero-protection,
+  utilization ratios where the denominator metric name doesn't contain
+  `total`, `up{...}` used without a `job` selector.
+- **Alert hysteresis sanity**: warns when an alert's expression is
+  duration-sensitive but the rule has no `for:` at all (a distinct,
+  static check from the separate `alert-hysteresis` tool, which instead
+  tunes an *existing* `for:` value against real firing history).
+
+## Reading the output
+
+Check mode groups issues by file:
+
+```
+./alerts/api-alerts.yml:
+  - Metric 'httpRequestCount' should use snake_case, not camelCase
+  - Expression should use multiline formatting: sum(rate(http_requests_total...
+
+Found formatting issues in 1/12 files
+Run with --fix to automatically format
+```
+
+Exit code is `1` whenever any file has issues in check mode (or a write
+error occurs in fix mode), `0` otherwise. Every issue is plain English —
+there's no machine-readable JSON mode, so an agent should parse them as
+free text and either explain them to the user or run `--fix` and re-check.
+
+## Agent workflow
+
+1. Run `promql-fmt --check <path>` first. If exit code is 0, nothing to do.
+2. If issues are found and they're purely formatting (multiline/aggregation
+   style), prefer `promql-fmt --fix <path>` over manual edits, then re-run
+   `--check` to confirm.
+3. If issues are best-practice warnings (naming, instrumentation), surface
+   them to the user — these often require a human judgment call (e.g.
+   renaming a metric is a breaking change for dashboards/alerts elsewhere).
+4. In CI, use `--check` only; never run `--fix` unattended in a pipeline
+   that auto-commits, since some rewrites (removing a "redundant"
+   aggregation clause) change semantics if the assumption about matching
+   labels doesn't actually hold — treat `--fix` output as something a human
+   reviews before merge, same as any auto-formatter.

--- a/dot_claude/skills/stale-alerts-analyzer/SKILL.md
+++ b/dot_claude/skills/stale-alerts-analyzer/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: stale-alerts-analyzer
+description: Query a live Prometheus's historical ALERTS series to find alert rules that haven't fired in a long time — "dead code analysis" for alerting rules, surfacing candidates for deletion or threshold review. Use interactively during alert-quality/on-call hygiene reviews, not as a CI gate. Requires a live Prometheus with sufficient ALERTS retention.
+license: BSD-3-Clause
+---
+
+# stale-alerts-analyzer
+
+Cross-references every `alert:` name defined in a rules file against
+Prometheus's historical `ALERTS` series to find ones that haven't fired
+within a configurable time horizon. Functionally this is dead-code
+analysis applied to alerting rules: an alert nobody has seen fire in a
+year is either (a) protecting against something that no longer happens,
+(b) has a threshold too conservative to ever trigger, or (c) is genuinely
+still needed and just hasn't had cause to fire — this tool flags
+candidates, a human makes the call.
+
+## When to use this skill
+
+- Periodic alert hygiene / on-call load review: "which of our alerts are
+  actually doing anything?"
+- Before a large alerting-rules refactor, to identify safe-to-remove dead
+  weight.
+- **Not** a CI gate: it depends on live, non-reproducible production
+  history, and "delete this alert" is a decision that deserves a human
+  in the loop, even when using `--fix`.
+
+## Prerequisites
+
+- A reachable Prometheus (or Prometheus-API-compatible Thanos/Cortex/
+  Mimir) that has actually been evaluating the rules file's alerts, so
+  `ALERTS` has history.
+- **Retention vs. `--timehorizon` matters just as much as for
+  `alert-hysteresis`**: an alert reported "stale (no firings in 380
+  days)" is meaningless if Prometheus only retains 30 days — the tool has
+  no way to distinguish "never fired" from "fired outside what Prometheus
+  still remembers." Confirm retention before trusting a long horizon.
+
+## Setup
+
+```bash
+go build -o bin/stale-alerts-analyzer ./cmd/stale-alerts-analyzer
+# or: go install github.com/conallob/o11y-analysis-tools/cmd/stale-alerts-analyzer@latest
+```
+
+## Usage
+
+```
+stale-alerts-analyzer [options]
+```
+
+| Flag | Default | Effect |
+|---|---|---|
+| `--prometheus-url` | `http://localhost:9090` | Prometheus API base URL. Required. |
+| `--rules` | *(required)* | Path to the rules YAML file whose alert names to check. |
+| `--timehorizon` | `12M` | Staleness lookback window. Accepts Go durations (`h`, `m`, `s`) **and** extended units: `d` (days), `w` (weeks), `M` (30-day months), `y` (365-day years) — e.g. `90d`, `6M`, `1y`. |
+| `--fix` | `false` | Delete the identified stale alerts directly from the rules file. |
+| `--verbose` | `false` | Print query details while fetching. |
+
+Note: unlike the other tools, there is no `--output=json` flag despite
+being mentioned in the top-level README's examples — as currently
+implemented, output is always the human-readable report below; there is
+no machine-readable export mode. Don't tell a user to pipe `--output=json`
+expecting it to work.
+
+### Typical invocations
+
+```bash
+# Default: alerts with no firings in the last 12 months
+stale-alerts-analyzer --prometheus-url=http://prometheus:9090 --rules=./alerts.yml
+
+# Shorter horizon in days
+stale-alerts-analyzer --prometheus-url=http://prometheus:9090 --rules=./alerts.yml --timehorizon=90d
+
+# Delete stale alerts directly (review the diff before committing!)
+stale-alerts-analyzer --fix --prometheus-url=http://prometheus:9090 --rules=./alerts.yml --timehorizon=1y
+```
+
+## Reading the output
+
+Lists active alerts (fired within the horizon, with last-fired time and
+age) separately from stale alerts (last-fired time or "Never" within the
+lookback), followed by a summary with total/active/stale counts and a
+never-fired-vs-fired-but-stale breakdown. Exit code `1` when stale alerts
+exist and `--fix` wasn't passed (so the run can be used as a nudge, even
+if you don't want it as a hard CI gate); `0` when nothing is stale or
+after a successful `--fix`.
+
+## Agent workflow
+
+1. Run without `--fix` first and read the stale list with the user —
+   "stale" here is a signal to investigate, not an automatic deletion
+   order. A dead-man's-switch-style alert (e.g. `Watchdog`) is *expected*
+   to never "stale-fire" in the sense this tool measures, since it fires
+   continuously rather than transiently; don't recommend deleting
+   continuously-firing meta-alerts just because they show odd stats. This
+   tool has no built-in exclude list (despite an `--exclude` flag being
+   mentioned in the top-level README) — as currently implemented there is
+   no such flag, so filter candidates yourself before recommending
+   deletion.
+2. For each stale candidate, distinguish "never fired" from "fired, but
+   outside the horizon" using the printed breakdown — the former is a
+   stronger deletion signal than the latter.
+3. Cross-check `--timehorizon` against the target Prometheus's actual
+   retention before treating a "stale" verdict as reliable.
+4. Prefer proposing a deletion PR for human review over `--fix` unless
+   explicitly asked to apply it directly — removing an alert is a
+   coverage-reducing change.


### PR DESCRIPTION
## Summary

- Add a `promql-cody` agent (`dot_claude/agents/promql-cody.md`) specializing in PromQL/Alertmanager rule maintenance via the [o11y-analysis-tools](https://github.com/conallob/o11y-analysis-tools) CLI suite
- Copy the six per-tool Agent Skills plus the `promql-cody` orchestrator skill from that repo into `dot_claude/skills/`: `promql-fmt`, `label-check`, `autogen-promql-tests`, `e2e-alertmanager-test`, `alert-hysteresis`, `stale-alerts-analyzer`, `promql-cody`
- Register the new agent and skills in `dot_claude/CLAUDE.md`

## Original Prompt

```
Let's add a new agent and skills to my Claude config, specifically https://github.com/conallob/o11y-analysis-tools
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHG2EZi9fsAKAfvinT2yD4)_